### PR TITLE
Fix for bug JENKINS-6209.

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -563,7 +563,7 @@ public class SubversionSCM extends SCM implements Serializable {
 
 
     /*package*/ static Map<String,Long> parseRevisionFile(AbstractBuild<?,?> build) throws IOException {
-        return parseRevisionFile(build,false);
+        return parseRevisionFile(build,false,false);
     }
 
     /**
@@ -573,9 +573,10 @@ public class SubversionSCM extends SCM implements Serializable {
      *      If true, this method will go back the build history until it finds a revision file.
      *      A build may not have a revision file for any number of reasons (such as failure, interruption, etc.)
      * @return
-     *      map from {@link SvnInfo#url Subversion URL} to its revision.
+     *      map from {@link SvnInfo#url Subversion URL} to its revision.  If there is more than one, choose
+     *      the one with the least revision
      */
-    /*package*/ static Map<String,Long> parseRevisionFile(AbstractBuild<?,?> build, boolean findClosest) throws IOException {
+    /*package*/ static Map<String,Long> parseRevisionFile(AbstractBuild<?,?> build, boolean findClosest, boolean prunePinnedExternals) throws IOException {
         Map<String,Long> revisions = new HashMap<String,Long>(); // module -> revision
 
         if (findClosest) {
@@ -597,15 +598,35 @@ public class SubversionSCM extends SCM implements Serializable {
             try {
                 String line;
                 while((line=br.readLine())!=null) {
-                    int index = line.lastIndexOf('/');
+                	boolean isPinned = false;
+                	int indexLast = line.length();
+                	if (line.lastIndexOf("::p") == indexLast-3) {
+                		isPinned = true;
+                		indexLast -= 3;
+                	}
+                	int index = line.lastIndexOf('/');
                     if(index<0) {
                         continue;   // invalid line?
                     }
                     try {
-                        revisions.put(line.substring(0,index), Long.parseLong(line.substring(index+1)));
-                    } catch (NumberFormatException e) {
-                        // perhaps a corrupted line. ignore
-                    }
+                    	String url = line.substring(0, index);
+                    	long revision = Long.parseLong(line.substring(index+1,indexLast));
+                    	Long oldRevision = revisions.get(url);
+                    	if (isPinned) {
+                    		if (!prunePinnedExternals) {
+                    			if (oldRevision == null)
+                    				// If we're writing pinned, only write if there are no unpinned
+                    				revisions.put(url, revision);
+                    		}
+                    	} else {
+                    		// unpinned
+                        	if (oldRevision == null || oldRevision > revision)
+                        		// For unpinned, take minimum
+                        		revisions.put(url, revision);
+                    	}
+                    	} catch (NumberFormatException e) {
+                    		// perhaps a corrupted line. ignore
+                    	}
                 }
             } finally {
                 br.close();
@@ -659,11 +680,15 @@ public class SubversionSCM extends SCM implements Serializable {
         // write out the revision file
         PrintWriter w = new PrintWriter(new FileOutputStream(getRevisionFile(build)));
         try {
-            Map<String,SvnInfo> revMap = workspace.act(new BuildRevisionMapTask(build, this, listener, externals));
-            for (Entry<String,SvnInfo> e : revMap.entrySet()) {
-                w.println( e.getKey() +'/'+ e.getValue().revision );
+            List<SvnInfoP> pList = workspace.act(new BuildRevisionMapTask(build, this, listener, externals));
+            List<SvnInfo> revList= new ArrayList<SvnInfo>(pList.size());
+            for (SvnInfoP p: pList) {
+            	if (p.pinned) 
+            		w.println( p.info.url +'/'+ p.info.revision + "::p");
+            	else
+            		w.println( p.info.url +'/'+ p.info.revision);
             }
-            build.addAction(new SubversionTagAction(build,revMap.values()));
+            build.addAction(new SubversionTagAction(build,revList));
         } finally {
             w.close();
         }
@@ -877,6 +902,20 @@ public class SubversionSCM extends SCM implements Serializable {
         private static final long serialVersionUID = 1L;
     }
 
+    public static final class SvnInfoP implements Serializable {
+        /**
+         * SvnInfo with an indicator boolean indicating whether this is a pinned external
+         */
+        public final SvnInfo info;
+        public final boolean pinned;
+
+        public SvnInfoP(SvnInfo info, boolean pinned) {
+            this.info = info;
+            this.pinned = pinned;
+        }
+        private static final long serialVersionUID = 1L;
+    }
+
     /**
      * Information about svn:external
      */
@@ -948,7 +987,7 @@ public class SubversionSCM extends SCM implements Serializable {
      * @return
      *      null if the parsing somehow fails. Otherwise a map from the repository URL to revisions.
      */
-    private static class BuildRevisionMapTask implements FileCallable<Map<String,SvnInfo>> {
+    private static class BuildRevisionMapTask implements FileCallable<List<SvnInfoP>> {
         private final ISVNAuthenticationProvider authProvider;
         private final TaskListener listener;
         private final List<External> externals;
@@ -961,8 +1000,8 @@ public class SubversionSCM extends SCM implements Serializable {
             this.locations = parent.getLocations(build);
         }
 
-        public Map<String,SvnInfo> invoke(File ws, VirtualChannel channel) throws IOException {
-            Map<String/*module name*/,SvnInfo> revisions = new HashMap<String,SvnInfo>();
+        public List<SvnInfoP> invoke(File ws, VirtualChannel channel) throws IOException {
+            List<SvnInfoP> revisions = new ArrayList<SvnInfoP>();
 
             final SVNClientManager manager = createSvnClientManager(authProvider);
             try {
@@ -971,7 +1010,7 @@ public class SubversionSCM extends SCM implements Serializable {
                 for( ModuleLocation module : locations ) {
                     try {
                         SvnInfo info = new SvnInfo(svnWc.doInfo(new File(ws,module.getLocalDir()), SVNRevision.WORKING));
-                        revisions.put(info.url,info);
+                        revisions.add(new SvnInfoP(info, false));
                     } catch (SVNException e) {
                         e.printStackTrace(listener.error("Failed to parse svn info for "+module.remote));
                     }
@@ -979,11 +1018,10 @@ public class SubversionSCM extends SCM implements Serializable {
                 for(External ext : externals){
                     try {
                         SvnInfo info = new SvnInfo(svnWc.doInfo(new File(ws,ext.path),SVNRevision.WORKING));
-                        revisions.put(info.url,info);
+                        revisions.add(new SvnInfoP(info, ext.isRevisionFixed()));
                     } catch (SVNException e) {
                         e.printStackTrace(listener.error("Failed to parse svn info for external "+ext.url+" at "+ext.path));
                     }
-
                 }
 
                 return revisions;
@@ -1011,11 +1049,7 @@ public class SubversionSCM extends SCM implements Serializable {
     @Override
     public SCMRevisionState calcRevisionsFromBuild(AbstractBuild<?, ?> build, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
         // exclude locations that are svn:external-ed with a fixed revision.
-        Map<String,Long> wsRev = parseRevisionFile(build,true);
-        for (External e : parseExternalsFile(build.getProject()))
-            if (e.isRevisionFixed())
-                wsRev.remove(e.url);
-
+        Map<String,Long> wsRev = parseRevisionFile(build,true,true);
         return new SVNRevisionState(wsRev);
     }
 

--- a/src/main/java/hudson/scm/listtagsparameter/SimpleSVNDirEntryHandler.java
+++ b/src/main/java/hudson/scm/listtagsparameter/SimpleSVNDirEntryHandler.java
@@ -81,7 +81,6 @@ public class SimpleSVNDirEntryHandler implements ISVNDirEntryHandler {
     return sortedDirs;
   }
 
-  @Override
   public void handleDirEntry(SVNDirEntry dirEntry) throws SVNException {
     if(filterPattern != null && filterPattern.matcher(dirEntry.getName()).matches() || filterPattern == null) {
       dirs.put(dirEntry.getDate(), Util.removeTrailingSlash(dirEntry.getName()));

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -42,6 +42,7 @@ import hudson.Proc;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
+import hudson.model.Item;
 import hudson.scm.subversion.CheckoutUpdater;
 import hudson.scm.subversion.UpdateUpdater;
 import hudson.scm.subversion.UpdateWithCleanUpdater;
@@ -499,7 +500,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
                 		new ModuleLocation("https://svn.java.net/svn/hudson~svn/trunk/hudson/test-projects/testSubversionExclusion", "")),
                 true,null,null,null,null,null);
         p.setScm(scm);
-        configRoundtrip(p);
+        configRoundtrip((Item)p);
         verify(scm,(SubversionSCM)p.getScm());
     }
 


### PR DESCRIPTION
Fix bug JENKINS-6209 by modifying the revision.txt file to include which
items are pinned externals, rather than trying to remove them later. 

From the bug comment:

The fix is to change the revision.txt file to append a ::p when the revision is the result of a pinned externals. Then eliminating pinned externals from the map becomes trivial. Also, allow duplicate urls in the revision.txt file. When parsing it to produce a map you can either choose to eliminate pinned externals or not. Even if you don't, you always prefer a non-pinned revision in the map (where you can't have duplicates).

This works to fix my problem but there still are some issues:
1. The same URL can be pinned external more than once with same or different revisions or with no revision.
   1. The same URL can be checked out more than once into different local paths (not really a good idea but allowed).
   2. When computing change logs, if the same url is pinned external more than once, and the pin moves, then we see duplicates in the change log.

The right fix, I think, would go something like this:

revisions.txt would have 4 fields per line:

A. The local path
B. The url
C. The revision
D. The "pinned" flag, i.e. whether the revision is pinned

For externals, local path is a combination of the path in the svn:externals property and the module path.

Then have SVNRevisionState store a map from the path to a tuple of the other three fields. Rewrite polling and changelog building accordingly. This will let you do a better job of changelog building by accumulating multiple ranges that need to be queried for each url. For example it is possible that both the svn:external property changes to use a different revision on the pinned external and there are changes in the non-pinned checkout of the same resource. My current code will compute the proper change set if either one of these things changes (which is an improvement on the existing code), but will only produce the non-pinned changes when both occur.

However, I don't have time to do this right now, and this fix solves the problem most of the time.
