### PR TITLE
[FIXED JENKINS-10942] Set SVN_URL and SVN_REVISION even if there is @NNN 

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -516,14 +516,14 @@ public class SubversionSCM extends SCM implements Serializable {
         try {
             Map<String,Long> revisions = parseRevisionFile(build);
             if(svnLocations.length==1) {
-                Long rev = revisions.get(svnLocations[0].remote);
+                Long rev = revisions.get(getUrlWithoutRevision(svnLocations[0].remote));
                 if(rev!=null) {
                     env.put("SVN_REVISION",rev.toString());
                     env.put("SVN_URL",svnLocations[0].getURL());
                 }
             } else if(svnLocations.length>1) {
                 for(int i=0;i<svnLocations.length;i++) {
-                    Long rev = revisions.get(svnLocations[i].remote);
+                    Long rev = revisions.get(getUrlWithoutRevision(svnLocations[i].remote));
                     if(rev!=null) {
                         env.put("SVN_REVISION_"+(i+1),rev.toString());
                         env.put("SVN_URL_"+(i+1),svnLocations[i].getURL());


### PR DESCRIPTION
This pull request fixes problem that environmental variables SVN_URL and SVN_REVISION are not set if the URL contains @NNN or @HEAD.
