### PR TITLE
--depth option  to override default override --depth=INFINITY

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.405</version>
+    <version>1.450</version>
     <!--
     <version>1.420</version>
     -->

--- a/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
+++ b/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
@@ -1,3 +1,4 @@
+
 /*
  * The MIT License
  *
@@ -28,10 +29,10 @@ package hudson.scm.subversion;
 
 import hudson.Extension;
 import hudson.Util;
+import hudson.scm.SubversionSCM;
 import hudson.scm.SubversionSCM.External;
 import hudson.util.IOException2;
 import hudson.util.StreamCopyThread;
-import org.kohsuke.stapler.DataBoundConstructor;
 import org.tmatesoft.svn.core.SVNCancelException;
 import org.tmatesoft.svn.core.SVNDepth;
 import org.tmatesoft.svn.core.SVNException;
@@ -45,6 +46,11 @@ import java.io.PipedOutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.tmatesoft.svn.core.SVNDepth;
+import org.tmatesoft.svn.core.SVNException;
+import org.tmatesoft.svn.core.wc.SVNRevision;
+import org.tmatesoft.svn.core.wc.SVNUpdateClient;
 
 /**
  * {@link WorkspaceUpdater} that does a fresh check out.
@@ -57,54 +63,81 @@ public class CheckoutUpdater extends WorkspaceUpdater {
     @DataBoundConstructor
     public CheckoutUpdater() {}
 
-    @Override
     public UpdateTask createTask() {
-        return new UpdateTask() {
-            private static final long serialVersionUID = 8349986526712487762L;
+        return new UpdateTaskImpl();
+    }
+    protected static class UpdateTaskImpl extends UpdateTask {
+        public List<External> perform() throws IOException, InterruptedException {
+            final SVNUpdateClient svnuc = manager.getUpdateClient();
+            final List<External> externals = new ArrayList<External>(); // store discovered externals to here
 
-            @Override
-            public List<External> perform() throws IOException, InterruptedException {
-                final SVNUpdateClient svnuc = manager.getUpdateClient();
-                final List<External> externals = new ArrayList<External>(); // store discovered externals to here
+            cleanupBeforeCheckout();
 
-                listener.getLogger().println("Cleaning local Directory " + location.getLocalDir());
-                Util.deleteContentsRecursive(new File(ws, location.getLocalDir()));
-
-                // buffer the output by a separate thread so that the update operation
-                // won't be blocked by the remoting of the data
-                PipedOutputStream pos = new PipedOutputStream();
-                StreamCopyThread sct = new StreamCopyThread("svn log copier", new PipedInputStream(pos), listener.getLogger());
+            // buffer the output by a separate thread so that the update operation
+            // won't be blocked by the remoting of the data
+            PipedOutputStream pos = new PipedOutputStream();
+            StreamCopyThread sct = null;
+            if (listener != null) {
+                sct = new StreamCopyThread("svn log copier", new PipedInputStream(pos),
+                        listener.getLogger());
                 sct.start();
-
+            }
+            SubversionSCM.ModuleLocation location = null;
+            try {
+                for (final SubversionSCM.ModuleLocation l : locations) {
+                    location = l;
+                    SVNDepth svnDepth = getSvnDepth(l.getDepthOption());
+                    SVNRevision revision = getRevision(l);
+                    if (listener != null) {
+                        listener.getLogger().println("Checking out " + l.remote + " revision: " +
+                                (revision != null ? revision.toString() : "null") + " depth:" + svnDepth +
+                                " ignoreExternals: " + l.isIgnoreExternalsOption());
+                    }
+                    File local = new File(ws, l.getLocalDir());
+                    svnuc.setIgnoreExternals(l.isIgnoreExternalsOption());
+                    svnuc.setEventHandler(
+                            new SubversionUpdateEventHandler(new PrintStream(pos), externals, local, l.getLocalDir()));
+                    svnuc.doCheckout(l.getSVNURL(), local.getCanonicalFile(), SVNRevision.HEAD, revision,
+                            svnDepth, true);
+                }
+            } catch (SVNException e) {
+                //TODO find better solution than this workaround, svnkit uses the same exception and
+                // the same error code in case of aborted builds and builds with invalid credentials
+                if (e.getMessage() != null && e.getMessage().contains(SVN_CANCEL_EXCEPTION_MESSAGE)) {
+                    listener.error("Svn command was aborted");
+                    throw (InterruptedException) new InterruptedException().initCause(e);
+                }
+                e.printStackTrace(listener.error("Failed to check out " + location.remote));
+                return null;
+            } finally {
                 try {
-                    listener.getLogger().println("Checking out " + location.remote);
-
-                    File local = new File(ws, location.getLocalDir());
-                    svnuc.setEventHandler(new SubversionUpdateEventHandler(new PrintStream(pos), externals, local, location.getLocalDir()));
-                    svnuc.doCheckout(location.getSVNURL(), local.getCanonicalFile(), SVNRevision.HEAD, getRevision(location), SVNDepth.INFINITY, true);
-                } catch (SVNCancelException e) {
-                    listener.error("Subversion checkout has been canceled");
-                    throw (InterruptedException)new InterruptedException().initCause(e);
-                } catch (SVNException e) {
-                    e.printStackTrace(listener.error("Failed to check out " + location.remote));
-                    return null;
+                    pos.close();
                 } finally {
                     try {
-                        pos.close();
-                    } finally {
-                        try {
+                        if (sct != null) {
                             sct.join(); // wait for all data to be piped.
-                        } catch (InterruptedException e) {
-                            throw new IOException2("interrupted", e);
                         }
+                    } catch (InterruptedException e) {
+                        throw new IOException2("interrupted", e);
                     }
                 }
-
-                return externals;
             }
-        };
-    }
 
+            return externals;
+        }
+
+        /**
+         * Cleans workspace.
+         *
+         * @throws java.io.IOException IOException
+         */
+        protected void cleanupBeforeCheckout() throws IOException {
+            if (listener != null && listener.getLogger() != null) {
+                listener.getLogger().println("Cleaning workspace " + ws.getCanonicalPath());
+            }
+            Util.deleteContentsRecursive(ws);
+        }
+    }
     @Extension
     public static class DescriptorImpl extends WorkspaceUpdaterDescriptor {
         @Override

--- a/src/main/java/hudson/scm/subversion/UpdateWithRevertUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateWithRevertUpdater.java
@@ -25,12 +25,11 @@ package hudson.scm.subversion;
 
 import hudson.Extension;
 import hudson.scm.SubversionSCM.ModuleLocation;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.tmatesoft.svn.core.SVNDepth;
-import org.tmatesoft.svn.core.SVNException;
-
 import java.io.File;
 import java.io.IOException;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.tmatesoft.svn.core.SVNException;
+import org.tmatesoft.svn.core.wc.SVNWCClient;
 
 /**
  * {@link WorkspaceUpdater} that performs "svn revert" + "svn update"
@@ -51,14 +50,16 @@ public class UpdateWithRevertUpdater extends WorkspaceUpdater {
     // mostly "svn update" plus extra
     public static class TaskImpl extends UpdateUpdater.TaskImpl {
         /**
-         * 
+         *
          */
         private static final long serialVersionUID = -8562813147341259328L;
 
         @Override
         protected void preUpdate(ModuleLocation module, File local) throws SVNException, IOException {
-            listener.getLogger().println("Reverting " + local);
-            manager.getWCClient().doRevert(new File[]{local.getCanonicalFile()}, SVNDepth.INFINITY, null);
+            listener.getLogger().println("Reverting " + local + " ignoreExternals: " + module.isIgnoreExternalsOption());
+            final SVNWCClient svnwc = manager.getWCClient();
+            svnwc.setIgnoreExternals(module.isIgnoreExternalsOption());
+            svnwc.doRevert(new File[]{local.getCanonicalFile()}, getSvnDepth(module.getDepthOption()), null);
         }
     }
 

--- a/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
+++ b/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
@@ -32,6 +32,7 @@ import hudson.scm.SubversionSCM;
 import hudson.scm.SubversionSCM.External;
 import hudson.scm.SubversionSCM.ModuleLocation;
 import org.kohsuke.stapler.export.ExportedBean;
+import org.tmatesoft.svn.core.SVNDepth;
 import org.tmatesoft.svn.core.auth.ISVNAuthenticationProvider;
 import org.tmatesoft.svn.core.wc.SVNClientManager;
 import org.tmatesoft.svn.core.wc.SVNRevision;
@@ -75,6 +76,7 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
      * These fields are set by {@link SubversionSCM} before the invocation.
      */
     public static abstract class UpdateTask implements Serializable {
+        protected static final String SVN_CANCEL_EXCEPTION_MESSAGE = "svn: Operation cancelled";
         // fields that are set by the caller as context for the perform method
 
         /**
@@ -101,7 +103,7 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
         /**
          * Modules to check out. Never null.
          */
-        public ModuleLocation location;
+        protected ModuleLocation[] locations;
 
         /**
          * Build workspace. Never null.
@@ -129,7 +131,7 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
             t.authProvider = this.authProvider;
             t.timestamp = this.timestamp;
             t.listener = this.listener;
-            t.location = this.location;
+            t.locations = this.locations;
             t.revisions = this.revisions;
             t.ws = this.ws;
 
@@ -162,6 +164,15 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
             }
             r = l.getRevision(r);
             return r;
+        }
+
+        /**
+         * Returns {@link org.tmatesoft.svn.core.SVNDepth} by string value.
+         *
+         * @return {@link org.tmatesoft.svn.core.SVNDepth} value.
+         */
+        protected static SVNDepth getSvnDepth(String name) {
+            return SVNDepth.fromString(name);
         }
 
         private static final long serialVersionUID = 1L;

--- a/src/main/resources/hudson/scm/SubversionSCM/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/config.jelly
@@ -32,6 +32,17 @@ THE SOFTWARE.
         <f:entry title="${%Local module directory} (${%optional})" field="local">
           <f:textbox value="${loc!=null?loc.local:'.'}" />
         </f:entry>
+        <f:entry title="${%Repository depth option}" field="depthOption">
+            <select name="depthOption">
+                <f:option value="infinity" selected="${loc.depthOption=='infinity'}">infinity</f:option>
+                <f:option value="empty" selected="${loc.depthOption=='empty'}">empty</f:option>
+                <f:option value="files" selected="${loc.depthOption=='files'}">files</f:option>
+                <f:option value="immediates" selected="${loc.depthOption=='immediates'}">immediates</f:option>
+            </select>
+        </f:entry>
+        <f:entry title="${%Ignore externals option}" field="ignoreExternalsOption">
+          <f:checkbox default="false" checked="${loc.ignoreExternalsOption}"/>
+        </f:entry>
         <f:entry>
           <div align="right">
             <input type="button" value="${%Add more locations...}" class="repeatable-add show-if-last" />

--- a/src/main/resources/hudson/scm/SubversionSCM/help-depthOption.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-depthOption.html
@@ -1,0 +1,10 @@
+<div>
+  "--depth" option for checkout and update commands. Default value is "infinity".
+<p/> "empty" includes only the immediate target of the operation, not any of its file or directory children.
+<p/> "files" includes the immediate target of the operation and any of its immediate file children.
+<p/> "immediates" includes the immediate target of the operation and any of its immediate file or directory children. The directory children will themselves be empty.
+<p/> "infinity" includes the immediate target, its file and directory children, its children's children, and so on to full recursion.
+<p/>
+    More information can be found
+  <a href="http://svnbook.red-bean.com/en/1.5/svn.advanced.sparsedirs.html" target="_blank">here</a>.
+</div>

--- a/src/main/resources/hudson/scm/SubversionSCM/help-ignoreExternalsOption.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-ignoreExternalsOption.html
@@ -1,0 +1,6 @@
+<div>
+  "--ignore-externals" option will be used with svn checkout, svn update commands to disable externals definition processing.
+<p/>
+    More information can be found
+  <a href="http://svnbook.red-bean.com/en/1.5/svn.advanced.externals.html" target="_blank">here</a>.
+</div>

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -610,6 +610,8 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         for(int i=0; i<ll.length; i++) {
             assertEquals(ll[i].local, rl[i].local);
             assertEquals(ll[i].remote, rl[i].remote);
+            assertEquals(ll[i].getDepthOption(), rl[i].getDepthOption());
+            assertEquals(ll[i].isIgnoreExternalsOption(), rl[i].isIgnoreExternalsOption());
         }
 
         assertNullEquals(lhs.getExcludedRegions(), rhs.getExcludedRegions());
@@ -710,7 +712,8 @@ public class SubversionSCMTest extends AbstractSubversionTest {
 //        SLAVE_DEBUG_PORT = 8001;
         File repo = new CopyExisting(getClass().getResource("HUDSON-6030.zip")).allocate();
         SubversionSCM scm = new SubversionSCM(ModuleLocation.parse(new String[]{"file://" + repo.getPath()},
-                                                                   new String[]{"."}),
+                new String[]{"."},  null, null),
+
                                               new UpdateUpdater(), null, ".*/bar", "", "", "", "");
 
         FreeStyleProject p = createFreeStyleProject("testExcludedRegions");
@@ -742,7 +745,8 @@ public class SubversionSCMTest extends AbstractSubversionTest {
 //        SLAVE_DEBUG_PORT = 8001;
         File repo = new CopyExisting(getClass().getResource("HUDSON-6030.zip")).allocate();
         SubversionSCM scm = new SubversionSCM(ModuleLocation.parse(new String[]{"file://" + repo.getPath()},
-                                                                   new String[]{"."}),
+                new String[]{"."}, null, null),
+
                                               new UpdateUpdater(), null, "", "", "", "", ".*/foo");
 
         FreeStyleProject p = createFreeStyleProject("testExcludedRegions");


### PR DESCRIPTION
Created a  basic patch from  http://issues.hudson-ci.org/browse/HUDSON-777  to apply ít to Jenkins Subversion Plugin where feature is open since long time [https://issues.jenkins-ci.org/browse/JENKINS-777].

   -Feature provides now  option to choose --depth param  from FILE;EMPTY;INFINITY;IMMEDIATE parameters
screenshot :http://dl.dropbox.com/u/703638/subversionDepth.png

I hope according to  MIT License (which this code from hudson is patched here) will allow to do so.
Please have your comment on both IP and of course code suggestions as I am new to commiter community 

Cheers
Dharmesh
