### PR TITLE
JENKINS-6415 fix and fix that fail build when some files were left in directory on workspace but there was no .svn directory and we wanted to update it

### DIFF
--- a/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
+++ b/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
@@ -45,6 +45,7 @@ import java.io.PipedOutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
+import org.tmatesoft.svn.core.SVNErrorCode;
 
 /**
  * {@link WorkspaceUpdater} that does a fresh check out.
@@ -86,6 +87,10 @@ public class CheckoutUpdater extends WorkspaceUpdater {
                     listener.error("Subversion checkout has been canceled");
                     throw (InterruptedException)new InterruptedException().initCause(e);
                 } catch (SVNException e) {
+                    if (e.getErrorMessage().getErrorCode() == SVNErrorCode.BAD_URL) {
+                        listener.error("Failed to check out external from " + location.remote);
+                       throw (IOException)new IOException(e.getMessage());
+                    }
                     e.printStackTrace(listener.error("Failed to check out " + location.remote));
                     return null;
                 } finally {

--- a/src/main/java/hudson/scm/subversion/SubversionUpdateEventHandler.java
+++ b/src/main/java/hudson/scm/subversion/SubversionUpdateEventHandler.java
@@ -83,6 +83,9 @@ final class SubversionUpdateEventHandler extends SubversionEventHandlerImpl {
          * SVNEvent.getAction() and SVNEventAction.UPDATE_-like constants.
          */
         SVNEventAction action = event.getAction();
+        if (action == SVNEventAction.FAILED_EXTERNAL) {           
+            throw new SVNException( SVNErrorMessage.create(SVNErrorCode.BAD_URL, event.getErrorMessage()) );
+        }
         if (action == SVNEventAction.UPDATE_EXTERNAL) {
             // for externals definitions
             SVNExternal ext = event.getExternalInfo();

--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -138,6 +138,10 @@ public class UpdateUpdater extends WorkspaceUpdater {
                 listener.error("Subversion update has been canceled");
                 throw (InterruptedException)new InterruptedException().initCause(e);
             } catch (final SVNException e) {
+                if (e.getErrorMessage().getErrorCode() == SVNErrorCode.BAD_URL){
+                    listener.error("Failed to update external from " + location.remote);
+                    throw (IOException)new IOException(e.getMessage());
+                }
                 if (e.getErrorMessage().getErrorCode() == SVNErrorCode.WC_LOCKED) {
                     // work space locked. try fresh check out
                     listener.getLogger().println("Workspace appear to be locked, so getting a fresh workspace");

--- a/src/main/resources/hudson/scm/subversion/Messages.properties
+++ b/src/main/resources/hudson/scm/subversion/Messages.properties
@@ -67,7 +67,7 @@ SubversionSCM.pollChanges.exception=\
   Failed to check repository revision for {0}
 
 SubversionUpdateEventHandler.FetchExternal=\
-  Fetching ''{0}'' at {1} into ''{2}''
+  Fetching external ''{0}'' at {1} into ''{2}''
 SubversionTagAction.DisplayName.HasNoTag=Tag this build
 SubversionTagAction.DisplayName.HasATag=Subversion tag
 SubversionTagAction.DisplayName.HasTags=Subversion tags


### PR DESCRIPTION
Example of problem when some files were in workspace:

svn co http://repository/dir
.svn/
other_file
/somefolder/
-  .svn/
- a_file

after clean(deleting .svn directories) in workspace

.svn/
other_file
/somefolder/
- a_file

There was error but subversion plugin went over that and pulled other externals if any and build without failure. 

With those changes now build should failure when error occurs during update/checkout of svn:externals. But the major fix is in JENKINS-6415 which silently omited problems with externals.
