### PR TITLE
Provide SvnInfos for all module locations

### DIFF
--- a/src/main/java/hudson/scm/SubversionRepositoryStatus.java
+++ b/src/main/java/hudson/scm/SubversionRepositoryStatus.java
@@ -14,7 +14,9 @@ import hudson.util.QueryParameterMap;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Logger;
@@ -97,7 +99,6 @@ public class SubversionRepositoryStatus extends AbstractModelObject {
             }
         }
 
-        OUTER:
         for (AbstractProject<?,?> p : Hudson.getInstance().getAllItems(AbstractProject.class)) {
             try {
                 SCM scm = p.getScm();
@@ -107,6 +108,10 @@ public class SubversionRepositoryStatus extends AbstractModelObject {
                 if (trigger!=null) triggerFound = true; else continue;
 
                 SubversionSCM sscm = (SubversionSCM) scm;
+                
+                List<SvnInfo> infos = new ArrayList<SvnInfo>();
+                
+                boolean jobMatches = false; 
                 for (ModuleLocation loc : sscm.getLocations()) {
                     if (loc.getUUID(p).equals(uuid)) uuidFound = true; else continue;
 
@@ -118,14 +123,8 @@ public class SubversionRepositoryStatus extends AbstractModelObject {
                     if(remaining.startsWith("/"))   remaining=remaining.substring(1);
                     String remainingSlash = remaining + '/';
 
-                    final RevisionParameterAction[] actions;
                     if ( rev != -1 ) {
-                        SvnInfo info[] = { new SvnInfo(loc.getURL(), rev) };
-                        RevisionParameterAction action = new RevisionParameterAction(info);
-                        actions = new RevisionParameterAction[] {action};
-
-                    } else {
-                        actions = new RevisionParameterAction[0];
+                        infos.add(new SvnInfo(loc.getURL(), rev));
                     }
 
                     for (String path : affectedPath) {
@@ -133,14 +132,26 @@ public class SubversionRepositoryStatus extends AbstractModelObject {
                         || remaining.length()==0/*when someone is checking out the whole repo (that is, m==n)*/) {
                             // this project is possibly changed. poll now.
                             // if any of the data we used was bogus, the trigger will not detect a change
-                            LOGGER.fine("Scheduling the immediate polling of "+p);
-                            trigger.run(actions);
+                            jobMatches = true;
                             pathFound = true;
-
-                            continue OUTER;
                         }
                     }
                 }
+                
+                if (jobMatches) {
+                    LOGGER.fine("Scheduling the immediate polling of "+p);
+                    
+                    final RevisionParameterAction[] actions;
+                    if (infos.isEmpty()) {
+                        actions = new RevisionParameterAction[0];
+                    } else {
+                        actions = new RevisionParameterAction[] {
+                                new RevisionParameterAction(infos)};
+                    }
+                    
+                    trigger.run(actions);
+                }
+                
             } catch (SVNException e) {
                 LOGGER.log(WARNING,"Failed to handle Subversion commit notification",e);
             }

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -316,6 +316,13 @@ public class SubversionSCM extends SCM implements Serializable {
     public SubversionSCM(String svnUrl, String local) {
         this(new String[]{svnUrl},new String[]{local},true,null,null,null,null);
     }
+    
+    /**
+     * Convenience constructor, especially during testing.
+     */
+    public SubversionSCM(String[] svnUrls, String[] locals) {
+        this(svnUrls,locals,true,null,null,null,null);
+    }
 
     /**
      * @deprecated

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -361,6 +361,26 @@ public class SubversionSCMTest extends AbstractSubversionTest {
 
         return p;
     }
+    
+    private FreeStyleProject createPostCommitTriggerJobMultipleSvnLocations() throws Exception {
+        // Disable crumbs because HTMLUnit refuses to mix request bodies with
+        // request parameters
+        hudson.setCrumbIssuer(null);
+
+        FreeStyleProject p = createFreeStyleProject();
+        String[] urls = new String[] {"https://svn.jenkins-ci.org/trunk/hudson/test-projects/trivial-ant",
+                "https://svn.jenkins-ci.org/trunk/hudson/test-projects/trivial-maven/"};
+
+        p.setScm(new SubversionSCM(urls, new String[] {"", ""}));
+        
+        SCMTrigger trigger = new SCMTrigger("0 */6 * * *");
+        p.addTrigger(trigger);
+        trigger.start(p, true);
+
+        return p;
+    }
+    
+    // 
 
     private FreeStyleBuild sendCommitTrigger(FreeStyleProject p, boolean includeRevision) throws Exception {
         String repoUUID = "71c3de6d-444a-0410-be80-ed276b4c234a";
@@ -372,6 +392,31 @@ public class SubversionSCMTest extends AbstractSubversionTest {
 
         if (includeRevision) {
             wr.setAdditionalHeader("X-Hudson-Subversion-Revision", "13000");
+        }
+        
+        WebConnection conn = wc.getWebConnection();
+        WebResponse resp = conn.getResponse(wr);
+        assertTrue(isGoodHttpStatus(resp.getStatusCode()));
+
+        waitUntilNoActivity();
+        FreeStyleBuild b = p.getLastBuild();
+        assertNotNull(b);
+        assertBuildStatus(Result.SUCCESS,b);
+
+        return b;
+    }
+    
+    private FreeStyleBuild sendCommitTriggerMultipleSvnLocations(FreeStyleProject p, boolean includeRevision) throws Exception {
+        String repoUUID = "71c3de6d-444a-0410-be80-ed276b4c234a";
+
+        WebClient wc = new WebClient();
+        WebRequestSettings wr = new WebRequestSettings(new URL(getURL() + "subversion/" + repoUUID + "/notifyCommit"), HttpMethod.POST);
+        wr.setRequestBody("A   trunk/hudson/test-projects/trivial-ant/build.xml\n" +
+        		"M   https://svn.jenkins-ci.org/trunk/hudson/test-projects/trivial-maven/src/main/");
+        wr.setAdditionalHeader("Content-Type", "text/plain;charset=UTF-8");
+
+        if (includeRevision) {
+            wr.setAdditionalHeader("X-Hudson-Subversion-Revision", "18075");
         }
         
         WebConnection conn = wc.getWebConnection();
@@ -403,6 +448,24 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         FreeStyleBuild b = sendCommitTrigger(p, true);
 
         assertTrue(getActualRevision(b, "https://svn.jenkins-ci.org/trunk/hudson/test-projects/trivial-ant") <= 13000);
+    }
+    
+    /**
+     * Tests a checkout triggered from the post-commit hook
+     */
+    public void testPostCommitTriggerMultipleSvnLocations() throws Exception {
+        FreeStyleProject p = createPostCommitTriggerJobMultipleSvnLocations();
+        FreeStyleBuild b = sendCommitTriggerMultipleSvnLocations(p, true);
+
+        assertTrue(getActualRevision(b, "https://svn.jenkins-ci.org/trunk/hudson/test-projects/trivial-ant") <= 18075);
+        Long actualRevision = getActualRevision(b, "https://svn.jenkins-ci.org/trunk/hudson/test-projects/trivial-maven");
+        assertEquals(Long.valueOf(18075), actualRevision);
+        
+        List<RevisionParameterAction> actions = b.getActions(RevisionParameterAction.class);
+        assertEquals(1, actions.size());
+        
+        RevisionParameterAction action = actions.get(0);
+        assertEquals(2, action.getRevisions().size());
     }
     
     /**


### PR DESCRIPTION
If a job had multiple SVN locations only the 1st matching one would be included in the RevisionParameterAction after a post commit hook
