### PR TITLE
Quite mode for dowloading of files

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -205,6 +205,8 @@ public class SubversionSCM extends SCM implements Serializable {
     private String excludedCommitMessages;
 
     private WorkspaceUpdater workspaceUpdater;
+    
+    private boolean quiteMode;
 
     // No longer in use but left for serialization compatibility.
     @Deprecated
@@ -280,13 +282,13 @@ public class SubversionSCM extends SCM implements Serializable {
                          boolean useUpdate, boolean doRevert, SubversionRepositoryBrowser browser, String excludedRegions, String excludedUsers, String excludedRevprop, String excludedCommitMessages,
                          String includedRegions) {
         this(locations, useUpdate?(doRevert?new UpdateWithRevertUpdater():new UpdateUpdater()):new CheckoutUpdater(),
-                browser, excludedRegions, excludedUsers, excludedRevprop, excludedCommitMessages, includedRegions);
+                browser, excludedRegions, excludedUsers, excludedRevprop, excludedCommitMessages, includedRegions, false);
     }
 
     @DataBoundConstructor
     public SubversionSCM(List<ModuleLocation> locations, WorkspaceUpdater workspaceUpdater,
                          SubversionRepositoryBrowser browser, String excludedRegions, String excludedUsers, String excludedRevprop, String excludedCommitMessages,
-                         String includedRegions) {
+                         String includedRegions, boolean quiteMode) {
         for (Iterator<ModuleLocation> itr = locations.iterator(); itr.hasNext();) {
             ModuleLocation ml = itr.next();
             String remote = Util.fixEmptyAndTrim(ml.remote);
@@ -301,6 +303,7 @@ public class SubversionSCM extends SCM implements Serializable {
         this.excludedRevprop = excludedRevprop;
         this.excludedCommitMessages = excludedCommitMessages;
         this.includedRegions = includedRegions;
+        this.quiteMode =quiteMode;
     }
 
     /**
@@ -416,6 +419,12 @@ public class SubversionSCM extends SCM implements Serializable {
     public String getExcludedRegions() {
         return excludedRegions;
     }
+    
+    
+    public boolean isQuiteMode(){
+        return quiteMode;
+    }
+
 
     public String[] getExcludedRegionsNormalized() {
         return (excludedRegions == null || excludedRegions.trim().equals(""))
@@ -737,7 +746,8 @@ public class SubversionSCM extends SCM implements Serializable {
                 return null;
             }
         }
-        
+        if(quiteMode)
+            listener.getLogger().println("svn run in quite mode");
         List<External> externals = new ArrayList<External>();
         for (ModuleLocation location : getLocations(env, build)) {
             List<External> externalsFound = workspace.act(new CheckOutTask(build, this, location, build.getTimestamp().getTime(), listener, env));
@@ -768,6 +778,7 @@ public class SubversionSCM extends SCM implements Serializable {
             this.location = location;
             this.revisions = build.getAction(RevisionParameterAction.class);
             this.task = parent.getWorkspaceUpdater().createTask();
+            this.quiteMode = parent.isQuiteMode();
         }
         
         public List<External> invoke(File ws, VirtualChannel channel) throws IOException {

--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -46,6 +46,8 @@ import org.tmatesoft.svn.core.wc.SVNWCClient;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PipedOutputStream;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -129,10 +131,16 @@ public class UpdateUpdater extends WorkspaceUpdater {
 
             final SVNUpdateClient svnuc = clientManager.getUpdateClient();
             final List<External> externals = new ArrayList<External>(); // store discovered externals to here
-
+            PrintStream outputStream  = null;
+            if(!quiteMode){
+                outputStream = listener.getLogger();
+            }
+            else{
+                outputStream = new PrintStream(new PipedOutputStream());
+            }
             try {
                 File local = new File(ws, location.getLocalDir());
-                svnuc.setEventHandler(new SubversionUpdateEventHandler(listener.getLogger(), externals, local, location.getLocalDir()));
+                svnuc.setEventHandler(new SubversionUpdateEventHandler(outputStream, externals, local, location.getLocalDir()));
 
                 SVNRevision r = getRevision(location);
 

--- a/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
+++ b/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
@@ -114,6 +114,11 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
          * Build workspace. Never null.
          */
         public File ws;
+        
+       /**
+         * Do svn checkout or update in quite mode
+         */
+        public boolean quiteMode;
 
         /**
          * If the build parameter is specified with specific version numbers, this field captures that. Can be null.
@@ -140,6 +145,7 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
             t.location = this.location;
             t.revisions = this.revisions;
             t.ws = this.ws;
+            t.quiteMode = this.quiteMode;
 
             return t.perform();
         }

--- a/src/main/resources/hudson/scm/SubversionSCM/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/config.jelly
@@ -60,5 +60,8 @@ THE SOFTWARE.
     <f:entry title="${%Exclusion revprop name}" field="excludedRevprop">
         <f:textbox checkUrl="'descriptorByName/hudson.scm.SubversionSCM/checkRevisionPropertiesSupported?value='+toValue(document.getElementById('svn.remote.loc'))"/>
     </f:entry>
+    <f:entry title="${%Download files in quite mode}" field="quiteMode">
+        <f:checkbox />
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/scm/SubversionSCM/help-quiteMode.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-quiteMode.html
@@ -1,0 +1,3 @@
+<div>
+ Do not write information about downloaded files into log during checkout or update.
+</div>

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -296,7 +296,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
             new ModuleLocation("https://svn.jenkins-ci.org/trunk/hudson/test-projects/trivial-ant@18075", null),
             new ModuleLocation("https://svn.jenkins-ci.org/trunk/hudson/test-projects/trivial-maven@HEAD", null)
         };
-        p.setScm(new SubversionSCM(Arrays.asList(locations), new CheckoutUpdater(), null, null, null, null, null, null));
+        p.setScm(new SubversionSCM(Arrays.asList(locations), new CheckoutUpdater(), null, null, null, null, null, null, false));
 
         CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
         p.getBuildersList().add(builder);
@@ -477,7 +477,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         String svnBase = "file://" + new CopyExisting(getClass().getResource("/svn-repo.zip")).allocate().toURI().toURL().getPath();
         SubversionSCM scm = new SubversionSCM(
                 Arrays.asList(new ModuleLocation(svnBase + "trunk", null), new ModuleLocation(svnBase + "branches", null)),
-                new CheckoutUpdater(), null, null, null, null, null, null);
+                new CheckoutUpdater(), null, null, null, null, null, null,false);
         p.setScm(scm);
         p.scheduleBuild2(0, new Cause.UserCause()).get();
 
@@ -503,14 +503,14 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         String svnBase = "file://" + new CopyExisting(getClass().getResource("/svn-repo.zip")).allocate().toURI().toURL().getPath();
         SubversionSCM scm = new SubversionSCM(
                 Arrays.asList(new ModuleLocation(svnBase + "trunk", "trunk")),
-                new UpdateUpdater(), null, null, null, null, null, null);
+                new UpdateUpdater(), null, null, null, null, null, null,false);
         p.setScm(scm);
         Run r1 = p.scheduleBuild2(0, new Cause.UserCause()).get();
         assertLogContains("Cleaning local Directory trunk", r1);
 
         scm = new SubversionSCM(
                 Arrays.asList(new ModuleLocation(svnBase + "trunk", "trunk"), new ModuleLocation(svnBase + "branches", "branches")),
-                new UpdateUpdater(), null, null, null, null, null, null);
+                new UpdateUpdater(), null, null, null, null, null, null,false);
         p.setScm(scm);
         Run r2 = p.scheduleBuild2(0, new Cause.UserCause()).get();
         assertLogContains("Updating " + svnBase + "trunk", r2);
@@ -529,7 +529,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
                 Arrays.asList(
                 		new ModuleLocation("https://svn.jenkins-ci.org/trunk/hudson/test-projects/testSubversionExclusion", "c"),
                 		new ModuleLocation("https://svn.jenkins-ci.org/trunk/hudson/test-projects/testSubversionExclusion", "d")),
-                new UpdateUpdater(),new Sventon(new URL("http://www.sun.com/"),"test"),"exclude","user","revprop","excludeMessage",null);
+                new UpdateUpdater(),new Sventon(new URL("http://www.sun.com/"),"test"),"exclude","user","revprop","excludeMessage",null, false);
         p.setScm(scm);
         submit(new WebClient().getPage(p,"configure").getFormByName("config"));
         verify(scm,(SubversionSCM)p.getScm());
@@ -537,7 +537,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         scm = new SubversionSCM(
         		Arrays.asList(
                 		new ModuleLocation("https://svn.jenkins-ci.org/trunk/hudson/test-projects/testSubversionExclusion", "c")),
-        		new CheckoutUpdater(),null,"","","","",null);
+        		new CheckoutUpdater(),null,"","","","",null,false);
         p.setScm(scm);
         submit(new WebClient().getPage(p,"configure").getFormByName("config"));
         verify(scm,(SubversionSCM)p.getScm());
@@ -550,7 +550,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         SubversionSCM scm = new SubversionSCM(
                 Arrays.asList(
                 		new ModuleLocation("https://svn.jenkins-ci.org/trunk/hudson/test-projects/testSubversionExclusion", "")),
-                new UpdateUpdater(),null,null,null,null,null,null);
+                new UpdateUpdater(),null,null,null,null,null,null,false);
         p.setScm(scm);
         configRoundtrip((Item)p);
         verify(scm,(SubversionSCM)p.getScm());
@@ -567,7 +567,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
                 
         SubversionSCM scm = new SubversionSCM(
                 locs,
-                new UpdateUpdater(), new Sventon(new URL("http://www.sun.com/"), "test"), "exclude", "user", "revprop", "excludeMessage",null);
+                new UpdateUpdater(), new Sventon(new URL("http://www.sun.com/"), "test"), "exclude", "user", "revprop", "excludeMessage",null,false);
         p.setScm(scm);
         submit(new WebClient().getPage(p, "configure").getFormByName("config"));
         ModuleLocation[] ml = ((SubversionSCM) p.getScm()).getLocations();
@@ -697,7 +697,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         FreeStyleProject p = createFreeStyleProject( "testExcludeByUser" );
         p.setScm(new SubversionSCM(
                 Arrays.asList( new ModuleLocation( "https://svn.jenkins-ci.org/trunk/hudson/test-projects/testSubversionExclusions@19438", null )),
-                new UpdateUpdater(), null, "", "dty", "", "", null)
+                new UpdateUpdater(), null, "", "dty", "", "", null, false)
                 );
         // Do a build to force the creation of the workspace. This works around
         // pollChanges returning true when the workspace does not exist.
@@ -716,7 +716,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         File repo = new CopyExisting(getClass().getResource("HUDSON-6030.zip")).allocate();
         SubversionSCM scm = new SubversionSCM(ModuleLocation.parse(new String[]{"file://" + repo.getPath()},
                                                                    new String[]{"."}),
-                                              new UpdateUpdater(), null, ".*/bar", "", "", "", "");
+                                              new UpdateUpdater(), null, ".*/bar", "", "", "", "", false);
 
         FreeStyleProject p = createFreeStyleProject("testExcludedRegions");
         p.setScm(scm);
@@ -748,7 +748,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         File repo = new CopyExisting(getClass().getResource("HUDSON-6030.zip")).allocate();
         SubversionSCM scm = new SubversionSCM(ModuleLocation.parse(new String[]{"file://" + repo.getPath()},
                                                                    new String[]{"."}),
-                                              new UpdateUpdater(), null, "", "", "", "", ".*/foo");
+                                              new UpdateUpdater(), null, "", "", "", "", ".*/foo", false);
 
         FreeStyleProject p = createFreeStyleProject("testExcludedRegions");
         p.setScm(scm);
@@ -979,7 +979,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
             new ModuleLocation("https://svn.jenkins-ci.org/trunk/hudson/test-projects/trivial-ant", null),
             new ModuleLocation("https://svn.jenkins-ci.org/trunk/hudson/test-projects/trivial-maven", null)
         };
-        p.setScm(new SubversionSCM(Arrays.asList(locations), new CheckoutUpdater(), null, null, null, null, null, null));
+        p.setScm(new SubversionSCM(Arrays.asList(locations), new CheckoutUpdater(), null, null, null, null, null, null, false));
 
         CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
         p.getBuildersList().add(builder);
@@ -1177,7 +1177,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
                     new ModuleLocation("svn://localhost/z", null)
                 };
 
-            b.setScm(new SubversionSCM(Arrays.asList(locations), new CheckoutUpdater(), null, null, null, null, null, null));
+            b.setScm(new SubversionSCM(Arrays.asList(locations), new CheckoutUpdater(), null, null, null, null, null, null, false));
 
             FreeStyleBuild build = assertBuildStatusSuccess(b.scheduleBuild2(0));
             FilePath ws = build.getWorkspace();


### PR DESCRIPTION
The output during svn checkout or update contains a lot of lines with info about downloaded files (like AU install .....). It takes a lot of place in logs and user often is not interested in this information. So I added the quite mode option.
