### PR TITLE
[FIXED JENKINS-14116] Update to older revision

### DIFF
--- a/src/main/java/hudson/scm/SubversionChangeLogBuilder.java
+++ b/src/main/java/hudson/scm/SubversionChangeLogBuilder.java
@@ -151,6 +151,13 @@ public final class SubversionChangeLogBuilder {
             return false;
         }
 
+        // handle case where previous workspace revision is newer than this revision
+        if (prevRev.compareTo(thisRev) > 0) {
+        	long temp = thisRev.longValue();
+        	thisRev = new Long(prevRev.longValue());
+        	prevRev = new Long(temp);
+        }
+        
         try {
             if(debug)
                 listener.getLogger().printf("Computing changelog of %1s from %2s to %3s\n",


### PR DESCRIPTION
Added check to generation of change set between previous workspace
(prevRev) and current workspace (thisRev) to correctly handle case when
prevRev > thisRev. Change set covers commits [prevRev+1, thisRev], which
is backwards when updating to an older revision, resulting in an
incorrect summary and, if prevRev=HEAD, throwing exceptions and failing
the build since HEAD+1 does not exist. Solution: if prevRev > thisRev,
swap values before generating change set.
