### PR TITLE
Add MatrixChildAction to RevisionAction so passed to all matrix configur...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.405</version>
+    <version>1.481</version>
     <!--
     <version>1.420</version>
     -->

--- a/src/main/java/hudson/scm/RevisionParameterAction.java
+++ b/src/main/java/hudson/scm/RevisionParameterAction.java
@@ -23,6 +23,7 @@
  */
 package hudson.scm;
 
+import hudson.matrix.MatrixChildAction;
 import hudson.model.InvisibleAction;
 import hudson.model.Action;
 import hudson.model.Queue;
@@ -43,7 +44,7 @@ import org.tmatesoft.svn.core.wc.SVNRevision;
  * 
  * @author Tom Huybrechts
  */
-public class RevisionParameterAction extends InvisibleAction implements Serializable, FoldableAction {
+public class RevisionParameterAction extends InvisibleAction implements Serializable, FoldableAction, MatrixChildAction {
 	
 	private static final long serialVersionUID = 1L;
 	private static final Logger LOGGER = Logger.getLogger(RevisionParameterAction.class.getName());


### PR DESCRIPTION
...ations

[FIXED JENKINS-14619] Depends on the change implemented in 1.481 for the MatrixChildAction
so that the Revision Actions are passed to all configurations.

Second part of fix for this issue.
