### PR TITLE
JENKINS-15440

### DIFF
--- a/src/main/resources/hudson/scm/SubversionMailAddressResolverImpl/global.jelly
+++ b/src/main/resources/hudson/scm/SubversionMailAddressResolverImpl/global.jelly
@@ -1,0 +1,22 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:section title="Subversion Mail Address resolver">
+        <f:entry title="Matching rules"
+                 description="Rules to retrieve user e-mail based on subversion repository">
+            <f:repeatable field="rules">
+                <table width="100%">
+                    <f:entry title="${%repository pattern}" field="pattern">
+                        <f:textbox/>
+                    </f:entry>
+                    <f:entry title="${%Domain suffix}" field="domain">
+                        <f:textbox/>
+                    </f:entry>
+                    <f:entry title="">
+                        <div align="right">
+                            <f:repeatableDeleteButton/>
+                        </div>
+                    </f:entry>
+                </table>
+            </f:repeatable>
+        </f:entry>
+    </f:section>
+</j:jelly>


### PR DESCRIPTION
make mailResolver rules configurable (was already a TODO in code comments)
so that user can just delete all rules to ~disable this extension, or configure custom ones if that makes sense for svn repository he's using
