### PR TITLE
JENKINS-13844: "Emulate clean checkout by..." does not work with 1.7 subversion repositories

### DIFF
--- a/src/main/java/hudson/scm/subversion/UpdateWithCleanUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateWithCleanUpdater.java
@@ -65,7 +65,7 @@ public class UpdateWithCleanUpdater extends WorkspaceUpdater {
 
             clientManager.getStatusClient().doStatus(local, null, SVNDepth.INFINITY, false, false, true, false, new ISVNStatusHandler() {
                 public void handleStatus(SVNStatus status) throws SVNException {
-                    SVNStatusType s = status.getContentsStatus();
+                    SVNStatusType s = status.getCombinedNodeAndContentsStatus();
                     if (s == SVNStatusType.STATUS_UNVERSIONED || s == SVNStatusType.STATUS_IGNORED || s == SVNStatusType.STATUS_MODIFIED) {
                         listener.getLogger().println("Deleting "+status.getFile());
                         try {


### PR DESCRIPTION
Patch that fixes the problem of subversion plugin not deleting unversioned files in 1.7 working copies, despite being configured to "emulate clean checkout".

Bug report:
https://issues.jenkins-ci.org/browse/JENKINS-13844
