### PR TITLE
Fix for JENKINS-2556

### DIFF
--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -90,7 +90,7 @@ public class UpdateUpdater extends WorkspaceUpdater {
                 String url = location.getURL();
                 
                 if (!svnInfo.url.equals(url)) {
-                    if (location.getSVNURL().toString().startsWith(svnkitInfo.getRepositoryRootURL().toString())) {
+                    if (isSameRepository(location, svnkitInfo)) {
                         listener.getLogger().println("Switching from " + svnInfo.url + " to " + url);
                         return SvnCommandToUse.SWITCH;
                     } else {
@@ -108,6 +108,10 @@ public class UpdateUpdater extends WorkspaceUpdater {
                 return SvnCommandToUse.CHECKOUT;
             }
             return SvnCommandToUse.UPDATE;
+        }
+
+        private boolean isSameRepository(ModuleLocation location, SVNInfo svnkitInfo) throws SVNException {
+            return location.getSVNURL().toString().startsWith(svnkitInfo.getRepositoryRootURL().toString());
         }
 
         /**


### PR DESCRIPTION
Detect when a "svn switch" can be used rather than a "svn checkout" in the UpdateUpdater.
