### PR TITLE
Provide helpful diagnostics when env vars unset

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -611,22 +611,22 @@ public class SubversionSCM extends SCM implements Serializable {
             if(svnLocations.length==1) {
                 // for backwards compatibility if there's only a single modulelocation, we also set
                 // SVN_REVISION and SVN_URL without '_n'
-                String url = SvnHelper.getUrlWithoutRevision(svnLocations[0].remote);
+                String url = svnLocations[0].getURL();
                 Long rev = revisions.get(url);
                 if(rev!=null) {
                     env.put("SVN_REVISION",rev.toString());
-                    env.put("SVN_URL",svnLocations[0].getURL());
+                    env.put("SVN_URL",url);
                 } else {
                     LOGGER.log(WARNING, "no revision found corresponding to {0}; known: {1}", new Object[] {url, revisions.keySet()});
                 }
             }
             
             for(int i=0;i<svnLocations.length;i++) {
-                String url = SvnHelper.getUrlWithoutRevision(svnLocations[i].remote);
+                String url = svnLocations[i].getURL();
                 Long rev = revisions.get(url);
                 if(rev!=null) {
                     env.put("SVN_REVISION_"+(i+1),rev.toString());
-                    env.put("SVN_URL_"+(i+1),svnLocations[i].getURL());
+                    env.put("SVN_URL_"+(i+1),url);
                 } else {
                     LOGGER.log(WARNING, "no revision found corresponding to {0}; known: {1}", new Object[] {url, revisions.keySet()});
                 }
@@ -2340,7 +2340,7 @@ public class SubversionSCM extends SCM implements Serializable {
          */
         public String getLocalDir() {
             if(local==null) 
-                return getLastPathComponent(SvnHelper.getUrlWithoutRevision(remote));
+                return getLastPathComponent(getURL());
             return local;
         }
 


### PR DESCRIPTION
A user complained that `$SVN_REVISION_1` etc. were not getting set under some conditions (when variables were defined on a containing CloudBees Folder). This patch should at least provide more useful diagnostics in the logger (`hudson.scm.SubversionSCM`).
