### PR TITLE
introduce abstract class for post commit hook to decouple the payload processing from hook trigger logic

### DIFF
--- a/src/main/java/hudson/scm/AbstractPostCommitHookReceiver.java
+++ b/src/main/java/hudson/scm/AbstractPostCommitHookReceiver.java
@@ -1,0 +1,182 @@
+package hudson.scm;
+
+import hudson.model.AbstractModelObject;
+import hudson.model.AbstractProject;
+import hudson.model.Hudson;
+import hudson.triggers.SCMTrigger;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+import org.tmatesoft.svn.core.SVNException;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.WARNING;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public abstract class AbstractPostCommitHookReceiver extends AbstractModelObject {
+
+    protected abstract ModuleMatcher matcher(StaplerRequest req);
+
+    protected abstract long getRevision(StaplerRequest req);
+
+    protected abstract Set<String> getAffectedPath(StaplerRequest req) throws IOException;
+
+
+    boolean doesIgnorePostCommitHooks(SCMTrigger trigger) {
+        if (IS_IGNORE_POST_COMMIT_HOOKS_METHOD == null)
+            return false;
+
+        try {
+            return (Boolean)IS_IGNORE_POST_COMMIT_HOOKS_METHOD.invoke(trigger, (Object[])null);
+        } catch (Exception e) {
+            LOGGER.log(WARNING,"Failure when calling isIgnorePostCommitHooks",e);
+            return false;
+        }
+    }
+
+    /**
+     * Notify the commit to this repository.
+     *
+     * <p>
+     * Because this URL is not guarded, we can't really trust the data that's sent to us. But we intentionally
+     * don't protect this URL to simplify <tt>post-commit</tt> script set up.
+     */
+    @RequirePOST
+    public void doNotifyCommit(StaplerRequest req, StaplerResponse rsp) throws ServletException, IOException {
+        Set<String> affectedPath = getAffectedPath(req);
+
+        if(LOGGER.isLoggable(FINE))
+            LOGGER.fine("Change reported to Subversion repository "+getDisplayName()+" on "+affectedPath);
+
+        long rev = getRevision(req);
+
+        boolean scmFound = false, triggerFound = false, repositoryFound = false, pathFound = false;
+        ModuleMatcher matcher = matcher(req);
+
+        if (matcher == null) {
+            rsp.setStatus(SC_BAD_REQUEST);
+            return;
+        }
+
+        for (AbstractProject<?,?> p : this.jobProvider.getAllJobs()) {
+            if(p.isDisabled()) continue;
+            try {
+                SCM scm = p.getScm();
+                if (scm instanceof SubversionSCM) scmFound = true; else continue;
+
+                SCMTrigger trigger = p.getTrigger(SCMTrigger.class);
+                if (trigger!=null && !doesIgnorePostCommitHooks(trigger)) triggerFound = true; else continue;
+
+                SubversionSCM sscm = (SubversionSCM) scm;
+
+                List<SubversionSCM.SvnInfo> infos = new ArrayList<SubversionSCM.SvnInfo>();
+
+                boolean projectMatches = false;
+                for (SubversionSCM.ModuleLocation loc : sscm.getProjectLocations(p)) {
+                    if (matcher.match(p, loc)) {
+                        repositoryFound = true;
+                    } else continue;
+
+                    String m = loc.getSVNURL().getPath();
+                    String n = loc.getRepositoryRoot(p).getPath();
+                    if(!m.startsWith(n))    continue;   // repository root should be a subpath of the module path, but be defensive
+
+                    String remaining = m.substring(n.length());
+                    if(remaining.startsWith("/"))   remaining=remaining.substring(1);
+                    String remainingSlash = remaining + '/';
+
+                    if ( rev != -1 ) {
+                        infos.add(new SubversionSCM.SvnInfo(loc.getURL(), rev));
+                    }
+
+                    for (String path : affectedPath) {
+                        if(path.equals(remaining) /*for files*/ || path.startsWith(remainingSlash) /*for dirs*/
+                        || remaining.length()==0/*when someone is checking out the whole repo (that is, m==n)*/) {
+                            // this project is possibly changed. poll now.
+                            // if any of the data we used was bogus, the trigger will not detect a change
+                            projectMatches = true;
+                            pathFound = true;
+                        }
+                    }
+                }
+
+                if (projectMatches) {
+                    LOGGER.fine("Scheduling the immediate polling of "+p);
+
+                    final RevisionParameterAction[] actions;
+                    if (infos.isEmpty()) {
+                        actions = new RevisionParameterAction[0];
+                    } else {
+                        actions = new RevisionParameterAction[] {
+                                new RevisionParameterAction(infos)};
+                    }
+
+                    trigger.run(actions);
+                }
+
+            } catch (SVNException e) {
+                LOGGER.log(WARNING,"Failed to handle Subversion commit notification",e);
+            }
+        }
+
+        if (!scmFound)          LOGGER.warning("No subversion jobs found");
+        else if (!triggerFound) LOGGER.warning("No subversion jobs using SCM polling or all jobs using SCM polling are ignoring post-commit hooks");
+        else if (!repositoryFound)    LOGGER.warning("No subversion jobs using repository: " + getDisplayName());
+        else if (!pathFound)    LOGGER.fine("No jobs found matching the modified files");
+
+        rsp.setStatus(SC_OK);
+    }
+
+    static interface ModuleMatcher {
+
+        /**
+         * Determine if the subversion module on specified project match the repository this receiver is managing post
+         * commit hook for.
+         */
+        boolean match(AbstractProject<?, ?> p, SubversionSCM.ModuleLocation loc) throws SVNException;
+
+    }
+
+    static interface JobProvider {
+        @SuppressWarnings("rawtypes")
+        List<AbstractProject> getAllJobs();
+    }
+
+    // for tests
+    void setJobProvider(JobProvider jobProvider) {
+        this.jobProvider = jobProvider;
+    }
+
+    protected SubversionRepositoryStatus.JobProvider jobProvider = new SubversionRepositoryStatus.JobProvider() {
+        @SuppressWarnings("rawtypes")
+        // @Override
+        public List<AbstractProject> getAllJobs() {
+            return Hudson.getInstance().getAllItems(AbstractProject.class);
+        }
+    };
+
+
+    private static Method IS_IGNORE_POST_COMMIT_HOOKS_METHOD;
+    static {
+        try {
+            IS_IGNORE_POST_COMMIT_HOOKS_METHOD = SCMTrigger.class.getMethod("isIgnorePostCommitHooks", (Class[])null);
+        } catch (Exception e) {
+            // we're running in an older Jenkins version which doesn't have this method
+        }
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(AbstractPostCommitHookReceiver.class.getName());
+
+}

--- a/src/main/java/hudson/scm/SubversionRepositoryStatus.java
+++ b/src/main/java/hudson/scm/SubversionRepositoryStatus.java
@@ -27,6 +27,7 @@ import javax.servlet.ServletException;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.tmatesoft.svn.core.SVNException;
 
 /**
@@ -37,7 +38,7 @@ import org.tmatesoft.svn.core.SVNException;
  * @author Kohsuke Kawaguchi
  * @see SubversionStatus
  */
-public class SubversionRepositoryStatus extends AbstractModelObject {
+public class SubversionRepositoryStatus extends AbstractPostCommitHookReceiver {
     public final UUID uuid;
 
     public SubversionRepositoryStatus(UUID uuid) {
@@ -51,41 +52,41 @@ public class SubversionRepositoryStatus extends AbstractModelObject {
     public String getSearchUrl() {
         return uuid.toString();
     }
-    
-    static interface JobProvider {
-        @SuppressWarnings("rawtypes")
-        List<AbstractProject> getAllJobs();
+
+    @Override
+    protected ModuleMatcher matcher(StaplerRequest req) {
+        return new ModuleMatcher() {
+            public boolean match(AbstractProject<?, ?> p, ModuleLocation loc) throws SVNException {
+                return loc.getUUID(p).equals(uuid);
+            }
+        };
     }
-    
-    private JobProvider jobProvider = new JobProvider() {
-        @SuppressWarnings("rawtypes")
-        @Override
-        public List<AbstractProject> getAllJobs() {
-            return Hudson.getInstance().getAllItems(AbstractProject.class);
+
+    @Override
+    protected long getRevision(StaplerRequest req) {
+        // we can't reliably use req.getParameter() as it can try to parse the payload, which we've already consumed above.
+        // servlet container relies on Content-type to decide if it wants to parse the payload or not, and at least
+        // in case of Jetty, it doesn't check if the payload is
+        QueryParameterMap query = new QueryParameterMap(req);
+        String revParam = query.get("rev");
+        if (revParam == null) {
+            revParam = req.getHeader("X-Hudson-Subversion-Revision");
         }
-    };
-    private static Method IS_IGNORE_POST_COMMIT_HOOKS_METHOD;
-    
-    // for tests
-    void setJobProvider(JobProvider jobProvider) {
-        this.jobProvider = jobProvider;
+
+        long rev = -1;
+        if (revParam != null) {
+            rev = Long.parseLong(revParam);
+        }
+        return rev;
     }
 
-    /**
-     * Notify the commit to this repository.
-     *
-     * <p>
-     * Because this URL is not guarded, we can't really trust the data that's sent to us. But we intentionally
-     * don't protect this URL to simplify <tt>post-commit</tt> script set up.
-     */
-    public void doNotifyCommit(StaplerRequest req, StaplerResponse rsp) throws ServletException, IOException {
-        requirePOST();
-
+    @Override
+    protected Set<String> getAffectedPath(StaplerRequest req) throws IOException {
         // compute the affected paths
         Set<String> affectedPath = new HashSet<String>();
         String line;
         BufferedReader r = new BufferedReader(req.getReader());
-        
+
         try {
 	        while((line=r.readLine())!=null) {
 	        	if (LOGGER.isLoggable(FINER)) {
@@ -101,111 +102,9 @@ public class SubversionRepositoryStatus extends AbstractModelObject {
         } finally {
         	IOUtils.closeQuietly(r);
         }
-
-        if(LOGGER.isLoggable(FINE))
-            LOGGER.fine("Change reported to Subversion repository "+uuid+" on "+affectedPath);
-        boolean scmFound = false, triggerFound = false, uuidFound = false, pathFound = false;
-
-        // we can't reliably use req.getParameter() as it can try to parse the payload, which we've already consumed above.
-        // servlet container relies on Content-type to decide if it wants to parse the payload or not, and at least
-        // in case of Jetty, it doesn't check if the payload is
-        QueryParameterMap query = new QueryParameterMap(req);
-        String revParam = query.get("rev");
-        if (revParam == null) {
-            revParam = req.getHeader("X-Hudson-Subversion-Revision");
-        }
-
-        long rev = -1;
-        if (revParam != null) {
-            rev = Long.parseLong(revParam);
-        }
-
-        for (AbstractProject<?,?> p : this.jobProvider.getAllJobs()) {
-            if(p.isDisabled()) continue;
-            try {
-                SCM scm = p.getScm();
-                if (scm instanceof SubversionSCM) scmFound = true; else continue;
-
-                SCMTrigger trigger = p.getTrigger(SCMTrigger.class);
-                if (trigger!=null && !doesIgnorePostCommitHooks(trigger)) triggerFound = true; else continue;
-
-                SubversionSCM sscm = (SubversionSCM) scm;
-                
-                List<SvnInfo> infos = new ArrayList<SvnInfo>();
-                
-                boolean projectMatches = false; 
-                for (ModuleLocation loc : sscm.getProjectLocations(p)) {
-                    if (loc.getUUID(p).equals(uuid)) uuidFound = true; else continue;
-
-                    String m = loc.getSVNURL().getPath();
-                    String n = loc.getRepositoryRoot(p).getPath();
-                    if(!m.startsWith(n))    continue;   // repository root should be a subpath of the module path, but be defensive
-
-                    String remaining = m.substring(n.length());
-                    if(remaining.startsWith("/"))   remaining=remaining.substring(1);
-                    String remainingSlash = remaining + '/';
-
-                    if ( rev != -1 ) {
-                        infos.add(new SvnInfo(loc.getURL(), rev));
-                    }
-
-                    for (String path : affectedPath) {
-                        if(path.equals(remaining) /*for files*/ || path.startsWith(remainingSlash) /*for dirs*/
-                        || remaining.length()==0/*when someone is checking out the whole repo (that is, m==n)*/) {
-                            // this project is possibly changed. poll now.
-                            // if any of the data we used was bogus, the trigger will not detect a change
-                            projectMatches = true;
-                            pathFound = true;
-                        }
-                    }
-                }
-                
-                if (projectMatches) {
-                    LOGGER.fine("Scheduling the immediate polling of "+p);
-                    
-                    final RevisionParameterAction[] actions;
-                    if (infos.isEmpty()) {
-                        actions = new RevisionParameterAction[0];
-                    } else {
-                        actions = new RevisionParameterAction[] {
-                                new RevisionParameterAction(infos)};
-                    }
-                    
-                    trigger.run(actions);
-                }
-                
-            } catch (SVNException e) {
-                LOGGER.log(WARNING,"Failed to handle Subversion commit notification",e);
-            }
-        }
-
-        if (!scmFound)          LOGGER.warning("No subversion jobs found");
-        else if (!triggerFound) LOGGER.warning("No subversion jobs using SCM polling or all jobs using SCM polling are ignoring post-commit hooks");
-        else if (!uuidFound)    LOGGER.warning("No subversion jobs using repository: " + uuid);
-        else if (!pathFound)    LOGGER.fine("No jobs found matching the modified files");
-
-        rsp.setStatus(SC_OK);
-    }
-    
-    private boolean doesIgnorePostCommitHooks(SCMTrigger trigger) {
-        if (IS_IGNORE_POST_COMMIT_HOOKS_METHOD == null)
-            return false;
-        
-        try {
-            return (Boolean)IS_IGNORE_POST_COMMIT_HOOKS_METHOD.invoke(trigger, (Object[])null);
-        } catch (Exception e) {
-            LOGGER.log(WARNING,"Failure when calling isIgnorePostCommitHooks",e);
-            return false;
-        }
+        return affectedPath;
     }
 
-    static {
-        try {
-            IS_IGNORE_POST_COMMIT_HOOKS_METHOD = SCMTrigger.class.getMethod("isIgnorePostCommitHooks", (Class[])null);
-        } catch (Exception e) {
-            // we're running in an older Jenkins version which doesn't have this method
-        }
-    }
 
     private static final Logger LOGGER = Logger.getLogger(SubversionRepositoryStatus.class.getName());
 }

--- a/src/test/java/hudson/scm/SubversionRepositoryStatusTest.java
+++ b/src/test/java/hudson/scm/SubversionRepositoryStatusTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import hudson.model.AbstractProject;
-import hudson.scm.SubversionRepositoryStatus.JobProvider;
+import hudson.scm.AbstractPostCommitHookReceiver.JobProvider;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -37,7 +37,7 @@ public class SubversionRepositoryStatusTest {
         when(project.isDisabled()).thenReturn(true);
         
         JobProvider jobProvider = new JobProvider() {
-            @Override
+            //@Override
             public List<AbstractProject> getAllJobs() {
                 return Collections.singletonList(project);
             }


### PR DESCRIPTION
allows to implement alternate web-hook payload computation
introduced for cloudforge-plugin development, see https://github.com/jenkinsci/cloudforge-plugin/issues/3
could be used as well to support googlecode post-commit hook payload
