### PR TITLE
[JENKINS-18574] use main repo path in change log for svn:externals affected paths

### DIFF
--- a/src/main/java/hudson/scm/DirAwareSVNXMLLogHandler.java
+++ b/src/main/java/hudson/scm/DirAwareSVNXMLLogHandler.java
@@ -11,8 +11,11 @@
  */
 package hudson.scm;
 
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.Map;
 
 import org.tmatesoft.svn.core.ISVNLogEntryHandler;
 import org.tmatesoft.svn.core.SVNErrorCode;
@@ -79,11 +82,17 @@ public class DirAwareSVNXMLLogHandler extends SVNXMLLogHandler implements ISVNLo
    */
   public void handleLogEntry(SVNLogEntry logEntry) throws SVNException {
 
-      if (relativePath != null && logEntry.getChangedPaths() != null) {
-          for (String key : logEntry.getChangedPaths().keySet()) {
-              SVNLogEntryPath path = logEntry.getChangedPaths().get(key);
-              path.setPath(relativePath + path.getPath().substring(relativeUrl.length()));
+      if (logEntry.getChangedPaths() != null && relativePath != null) {
+          // convert external path reference to local relative path
+          Map<String, SVNLogEntryPath> changedPaths = new HashMap<String, SVNLogEntryPath>();
+          for (SVNLogEntryPath entry : logEntry.getChangedPaths().values()) {
+              String localPath = entry.getPath().substring(1); // path in svn log start with a '/'
+              localPath = relativePath + localPath.substring(relativeUrl.length());
+              // can't use entry.setPath(localPath) as FSPathChange duplicate myPath attribute then setPath().getPath() don't return same value
+              changedPaths.put(localPath, new SVNLogEntryPath(localPath, entry.getType(), entry.getCopyPath(), entry.getCopyRevision()));
           }
+          logEntry.getChangedPaths().clear();
+          logEntry.getChangedPaths().putAll(changedPaths);
       }
 
       try {
@@ -165,7 +174,7 @@ public class DirAwareSVNXMLLogHandler extends SVNXMLLogHandler implements ISVNLo
     }
 
     public void setRelativeUrl(String relativeUrl) {
-        this.relativeUrl = relativeUrl;
+        this.relativeUrl = relativeUrl.startsWith("/") ? relativeUrl.substring(1) : relativeUrl;
     }
 
 

--- a/src/main/java/hudson/scm/SubversionChangeLogBuilder.java
+++ b/src/main/java/hudson/scm/SubversionChangeLogBuilder.java
@@ -115,7 +115,7 @@ public final class SubversionChangeLogBuilder {
             }
             for(SubversionSCM.External ext : externals) {
                 ExternalPath e = getUrlForPath(build.getWorkspace().child(ext.path));
-                logHandler.setRelativePath(ext.path);
+                logHandler.setRelativePath( ext.path.startsWith("./") ? ext.path.substring(2) : ext.path );
                 logHandler.setRelativeUrl(e.path);
                 changelogFileCreated |= buildModule(e.url, svnlc, logHandler);
             }

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -1074,6 +1074,61 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         assertTrue(p.poll(StreamTaskListener.fromStdout()).hasChanges());
     }
 
+    public void testExternalsAffectedPaths() throws Exception {
+        // repository set as svn:externals
+        File ext = new CopyExisting(getClass().getResource("two-revisions.zip")).allocate();
+
+        // create and commit a file foo/README.txt in ext
+        FreeStyleProject forCommit = createFreeStyleProject();
+        SubversionSCM scmExt = new SubversionSCM("file://" + ext.toURI().toURL().getPath());
+        forCommit.setScm(scmExt);
+        forCommit.setAssignedLabel(hudson.getSelfLabel());
+        // Build once to get a working copy in job workspace
+        FreeStyleBuild b = assertBuildStatusSuccess(forCommit.scheduleBuild2(0).get());
+        FilePath foo = b.getWorkspace().child("foo");
+        foo.mkdirs();
+        FilePath newFile = foo.child("README.txt");
+        newFile.touch(System.currentTimeMillis());
+        SvnClientManager svnm = SubversionSCM.createClientManager(forCommit);
+        svnm.getWCClient().doAdd(new File(foo.getRemote()),false,false,false, SVNDepth.INFINITY, false,false);
+        SVNCommitClient cc = svnm.getCommitClient();
+        cc.doCommit(new File[]{new File(foo.getRemote()), new File(newFile.getRemote())},false,"added",null,null,false,false,SVNDepth.INFINITY);
+
+
+        // repository used by job
+        File repo = new CopyExisting(getClass().getResource("two-revisions.zip")).allocate();
+        SubversionSCM scm = new SubversionSCM("file://" + repo.toURI().toURL().getPath());
+        FreeStyleProject p = createFreeStyleProject();
+        scm.setPollFromMaster(true);
+        p.setScm(scm);
+
+        // setup foo directory in ext as svn:externals on "ext",
+        FreeStyleBuild bb = assertBuildStatusSuccess(p.scheduleBuild2(0).get());
+        String externalURL = "file://" + ext.toURI().toURL().getPath();
+        SVNPropertyValue externals = SVNPropertyValue.create("ext " + externalURL + "/foo");
+        SvnClientManager svnm2 = SubversionSCM.createClientManager(forCommit);
+        svnm2.getWCClient().doSetProperty(new File(bb.getWorkspace().getRemote()), "svn:externals", externals, true, SVNDepth.FILES, null, null);
+        svnm2.getCommitClient().doCommit(new File[]{new File(bb.getWorkspace().getRemote())},false,"externals",null,null,false,false,SVNDepth.INFINITY);
+
+        // foo/README.tx in ext is now => /ext/README.txt in repo
+
+        assertBuildStatusSuccess(p.scheduleBuild2(2).get());
+        assertFalse(p.poll(StreamTaskListener.fromStdout()).hasChanges());
+
+        // create a commit in ext
+        newFile = foo.child("something.txt");
+        newFile.touch(System.currentTimeMillis());
+        svnm.getWCClient().doAdd(new File(newFile.getRemote()), false, false, false, SVNDepth.INFINITY, false, false);
+        cc.doCommit(new File[]{new File(newFile.getRemote())},false,"added",null,null,false,false,SVNDepth.INFINITY);
+
+        FreeStyleBuild build = p.scheduleBuild2(2).get();
+        assertBuildStatusSuccess(build);
+        for (ChangeLogSet.Entry e : build.getChangeSet()) {
+            for (String path : e.getAffectedPaths()) {
+                assertEquals("ext/something.txt", path);
+            }
+        }
+    }
 
     public void testCompareSVNAuthentications() throws Exception {
         assertFalse(compareSVNAuthentications(new SVNUserNameAuthentication("me",true),new SVNSSHAuthentication("me","me",22,true)));


### PR DESCRIPTION
hack SVNXMLLogHandler so reported affected path match workspace relative directories, and maven plugin can compare with modules path to determine impacted modules to build.
