### PR TITLE
[FIXED JENKINS-19600] prefer trilead-ssh from plugin vs core classloader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,9 @@ THE SOFTWARE.
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
         <version>${maven-hpi-plugin.version}</version>
+        <configuration>
+          <maskClasses>com.trilead.ssh2.</maskClasses>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
svnkit 1.7.10 require trilead build217. jenkins 1.509 (LTS) provides incompatible build214
