### PR TITLE
[FIXED JENKINS-4613]compare hostname in case-insensitive manner

### DIFF
--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -87,7 +87,7 @@ public class UpdateUpdater extends WorkspaceUpdater {
                 SVNInfo svnkitInfo = parseSvnInfo(module);
                 SvnInfo svnInfo = new SvnInfo(svnkitInfo);
 
-                String url = location.getURL();
+                String url = location.getSVNURL().toString();
                 
                 if (!svnInfo.url.equals(url)) {
                     if (isSameRepository(location, svnkitInfo)) {


### PR DESCRIPTION
Solved remaining problem of https://issues.jenkins-ci.org/browse/JENKINS-4613
Normalize url with getSVNURL() as in isSameRepository() and avoid unnecessary switch.
