### PR TITLE
Added comment about the need for the ISVNSession.

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -2389,6 +2389,8 @@ public class SubversionSCM extends SCM implements Serializable {
 
         public SVNRepository openRepository(AbstractProject context) throws SVNException {
             return Hudson.getInstance().getDescriptorByType(DescriptorImpl.class).getRepository(context,getSVNURL(), new ISVNSession() {
+                // This is only used to determine the repo UUID.
+                // To prevent opening too many connections simultaneously, configure this session to not keep connections open.
                 public boolean keepConnection(SVNRepository repository) {
                     return false;
                 }


### PR DESCRIPTION
In response to https://github.com/jenkinsci/subversion-plugin/commit/3f09b1c6c0402235e1e4b8719a134f49d9c40766#commitcomment-5152466

Due to the caching issues that lead me to write #60 later, all ~7k jobs in my instance opened at least one connection to SVN. This was heavily clogging the tubes at the SVN server. With this change, the problem went away.
