### PR TITLE
JENKINS-5347 Fixed - Added use commit times on files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,13 @@ THE SOFTWARE.
       <version>1.5</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+        <groupId>uk.co.modular-it</groupId>
+        <artifactId>hamcrest-date</artifactId>
+        <version>0.9.5</version>
+        <scope>test</scope>
+    </dependency>
+	
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -143,13 +143,7 @@ THE SOFTWARE.
       <version>1.5</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-        <groupId>uk.co.modular-it</groupId>
-        <artifactId>hamcrest-date</artifactId>
-        <version>0.9.5</version>
-        <scope>test</scope>
-    </dependency>
-	
+
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness</artifactId>

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -267,6 +267,7 @@ public class SubversionSCM extends SCM implements Serializable {
 
     private boolean ignoreDirPropChanges;
     private boolean filterChangelog;
+    private boolean usingCommitTimes;
 
     /**
      * A cache of the svn:externals (keyed by project).
@@ -357,7 +358,7 @@ public class SubversionSCM extends SCM implements Serializable {
     public SubversionSCM(List<ModuleLocation> locations, WorkspaceUpdater workspaceUpdater,
             SubversionRepositoryBrowser browser, String excludedRegions, String excludedUsers, String excludedRevprop, String excludedCommitMessages,
             String includedRegions, boolean ignoreDirPropChanges) {
-        this(locations, workspaceUpdater, browser, excludedRegions, excludedUsers, excludedRevprop, excludedCommitMessages, includedRegions, ignoreDirPropChanges, false, null);
+        this(locations, workspaceUpdater, browser, excludedRegions, excludedUsers, excludedRevprop, excludedCommitMessages, includedRegions, ignoreDirPropChanges, false, null, false);
     }
 
     @DataBoundConstructor
@@ -365,7 +366,8 @@ public class SubversionSCM extends SCM implements Serializable {
                          SubversionRepositoryBrowser browser, String excludedRegions, String excludedUsers,
                          String excludedRevprop, String excludedCommitMessages,
                          String includedRegions, boolean ignoreDirPropChanges, boolean filterChangelog,
-                         List<AdditionalCredentials> additionalCredentials) {
+                         List<AdditionalCredentials> additionalCredentials, boolean usingCommitTimes) {
+        this.usingCommitTimes = usingCommitTimes;
         for (Iterator<ModuleLocation> itr = locations.iterator(); itr.hasNext(); ) {
             ModuleLocation ml = itr.next();
             String remote = Util.fixEmptyAndTrim(ml.remote);
@@ -674,6 +676,11 @@ public class SubversionSCM extends SCM implements Serializable {
       return filterChangelog;
     }
 
+    @Exported
+    public boolean isUsingCommitTimes() {
+      return usingCommitTimes;
+    }
+
     /**
      * Sets the <tt>SVN_REVISION_n</tt> and <tt>SVN_URL_n</tt> environment variables during the build.
      */
@@ -980,6 +987,7 @@ public class SubversionSCM extends SCM implements Serializable {
      */
     private static class CheckOutTask extends UpdateTask implements FileCallable<List<External>> {
         private final UpdateTask task;
+        private final boolean isUsingCommitTimes;
 
          public CheckOutTask(AbstractBuild<?, ?> build, SubversionSCM parent, ModuleLocation location, Date timestamp, TaskListener listener, EnvVars env) {
             this.authProvider = parent.createAuthenticationProvider(build.getParent(), location);
@@ -988,6 +996,7 @@ public class SubversionSCM extends SCM implements Serializable {
             this.location = location;
             this.revisions = build.getAction(RevisionParameterAction.class);
             this.task = parent.getWorkspaceUpdater().createTask();
+            this.isUsingCommitTimes = parent.isUsingCommitTimes();
         }
 
         public Set<String> getUnauthenticatedRealms() {
@@ -998,7 +1007,12 @@ public class SubversionSCM extends SCM implements Serializable {
         }
 
         public List<External> invoke(File ws, VirtualChannel channel) throws IOException {
-            clientManager = createClientManager(authProvider);
+            DefaultSVNOptions defaultSVNOptions = createDefaultSVNOptions();
+            if (isUsingCommitTimes) {
+                defaultSVNOptions.setUseCommitTimes(isUsingCommitTimes);
+            }
+            
+            clientManager = new SvnClientManager(SVNClientManager.newInstance(defaultSVNOptions, createSvnAuthenticationManager(authProvider)));
             manager = clientManager.getCore();
             this.ws = ws;
             try {

--- a/src/main/resources/hudson/scm/SubversionSCM/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/config.jelly
@@ -111,5 +111,8 @@ THE SOFTWARE.
     <f:entry title="${%Filter changelog}" field="filterChangelog">
         <f:checkbox />
     </f:entry>
+    <f:entry title="${%Set check out file dates to the 'last commit time'}" field="usingCommitTimes">
+        <f:checkbox />
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/scm/SubversionSCM/help-usingCommitTimes.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-usingCommitTimes.html
@@ -1,0 +1,7 @@
+<div>
+  If set Jenkins will set the file timestamps to the last commit time (of each file) when doing a checkout or an update. Otherwise Jenkins will set the current date as the timestamp of each file. 
+  <p>
+  Normally the working copy files have timestamps that reflect the last time they were touched by any process. This is generally convenient for most build systems as they look at timestamps as a way of deciding which files need to be recompiled.
+  In other situations, however, it's sometimes nice for the working copy files to have timestamps that reflect the last time they were changed in the repository. The svn export command always places these 'last-commit timestamps' on trees that it produces..
+  </p>
+</div>

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -1757,8 +1757,8 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         p.setScm(scm);
         
         FreeStyleBuild b = assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause()).get());
-        // Using long matching to prevent Timezone issues
-        assertThat(b.getWorkspace().child("b").lastModified(), is(1293845528558l));
+        // Using long matching to prevent Timezone issues, divided by 1000 as some OS does not return the exact milliseconds
+        assertThat(b.getWorkspace().child("b").lastModified() / 1000, is(1293845528l));
     }
     
     public void testNotUseCommitTimes() throws Throwable {
@@ -1773,7 +1773,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         p.setScm(scm);
         
         FreeStyleBuild b = assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause()).get());
-        // Using long matching to prevent Timezone issues
-        assertThat(b.getWorkspace().child("b").lastModified(), not(is(1293845528558l)));
+        // Using long matching to prevent Timezone issues, divided by 1000 as some OS does not return the exact milliseconds
+        assertThat(b.getWorkspace().child("b").lastModified() / 1000, not(is(1293845528l)));
     }
 }    

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -26,6 +26,7 @@
 package hudson.scm;
 
 import static hudson.scm.SubversionSCM.compareSVNAuthentications;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.jvnet.hudson.test.recipes.PresetData.DataSet.ANONYMOUS_READONLY;
@@ -74,6 +75,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -112,9 +114,6 @@ import org.tmatesoft.svn.core.wc.SVNCommitClient;
 import org.tmatesoft.svn.core.wc.SVNRevision;
 import org.tmatesoft.svn.core.wc.SVNStatus;
 import org.tmatesoft.svn.core.wc.SVNWCUtil;
-
-import uk.co.it.modular.hamcrest.date.DateMatchers;
-import uk.co.it.modular.hamcrest.date.Months;
 
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
@@ -1758,8 +1757,8 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         p.setScm(scm);
         
         FreeStyleBuild b = assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause()).get());
-        Date fileInWorkspaceLastModified = new Date(b.getWorkspace().child("b").lastModified());        
-        assertThat(fileInWorkspaceLastModified, DateMatchers.sameDay(2011, Months.JANUARY, 1));
+        // Using long matching to prevent Timezone issues
+        assertThat(b.getWorkspace().child("b").lastModified(), is(1293845528558l));
     }
     
     public void testNotUseCommitTimes() throws Throwable {
@@ -1774,7 +1773,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         p.setScm(scm);
         
         FreeStyleBuild b = assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause()).get());
-        Date fileInWorkspaceLastModified = new Date(b.getWorkspace().child("b").lastModified());        
-        assertThat(fileInWorkspaceLastModified, not(DateMatchers.sameDay(2011, Months.JANUARY, 1)));
+        // Using long matching to prevent Timezone issues
+        assertThat(b.getWorkspace().child("b").lastModified(), not(is(1293845528558l)));
     }
 }    


### PR DESCRIPTION
This fixes JENKINS-5347, we have a third party tool that uses the
timestamp on files to notify a cache in the tool to be updated. This fix
will add an option to the Subversion configuration to use commit times.
As the "use-commit-times" is a global configuration but we are only
interested in it as a per-project configuration to not affect our other
builds.