### PR TITLE
[JENKINS-21907] Raised visibility of SVNRevisionState to public.

### DIFF
--- a/src/main/java/hudson/scm/SVNRevisionState.java
+++ b/src/main/java/hudson/scm/SVNRevisionState.java
@@ -7,14 +7,14 @@ import java.util.Map;
  * {@link SCMRevisionState} for {@link SubversionSCM}. {@link Serializable} since we compute
  * this remote.
  */
-final class SVNRevisionState extends SCMRevisionState implements Serializable {
+public final class SVNRevisionState extends SCMRevisionState implements Serializable {
     /**
      * All the remote locations that we checked out. This includes those that are specified
      * explicitly via {@link SubversionSCM#getLocations()} as well as those that
      * are implicitly pulled in via svn:externals, but it excludes those locations that
      * are added via svn:externals in a way that fixes revisions.
      */
-    final Map<String,Long> revisions;
+    public final Map<String,Long> revisions;
 
     SVNRevisionState(Map<String, Long> revisions) {
         this.revisions = revisions;


### PR DESCRIPTION
In order to build other plugins that can access SVN revision information from existing builds, the action subclass hudson.scm.SVNRevisionState needs to have public instead of default visibility.
