### PR TITLE
Fix 'additional credentials' help

### DIFF
--- a/src/main/resources/hudson/scm/SubversionSCM/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/config.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
     <f:repeatableProperty field="locations" add="${%Add module...}" minimum="1"/>
   </f:entry>
   
-  <f:entry title="${%Additional Credentials}">
+  <f:entry title="${%Additional Credentials}" help="/descriptor/hudson.scm.SubversionSCM/help/additionalCredentials">
     <f:repeatableProperty field="additionalCredentials" add="${%Add additional credentials...}"/>
  </f:entry>
 

--- a/src/main/resources/hudson/scm/SubversionSCM/help-additionalCredentials.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-additionalCredentials.html
@@ -1,4 +1,23 @@
 <div>
-    If there are additional credentials required in order to obtain a complete checkout of the source, they can be
-    provided here.
+    <p>If there are additional credentials required in order to obtain a complete checkout of the source, they can be
+    provided here.</p>
+    <p>The <strong>realm</strong> is how the repository self-identifies to a client. It usually has the following format:</p>
+    <p><code>&lt;proto://host:port&gt; Realm Name</code></p>
+    <ul>
+        <li><code>proto</code> is the protocol, e.g. <code>http</code> or <code>svn</code>.</li>
+        <li><code>host</code> is the host how it's accessed by Jenkins, e.g. as IP address <code>192.168.1.100</code>, host name <code>svnserver</code>, or host name and domain <code>svn.example.org</code>.</li>
+        <li><code>port</code> is the port, even if not explicitly specified. By default, this is <code>80</code> for HTTP, <code>443</code> for HTTPS, 3690 for the <code>svn</code> protocol.</li>
+        <li><code>Realm Name</code> is how the repository self-identifies. Common options include <code>VisualSVN Server</code>, <code>Subversion Authentication</code> or the UUID of the repository.</li>
+    </ul>
+    <p>To find out the realm, you could do any of the following:</p>
+    <ul>
+        <li>If you access the repository via HTTP or HTTPS: Open the repo in a web browser without saved credentials. It will use the <code>Realm Name</code> (see above) in the authentication dialog.</li>
+        <li>Use the command line <code>svn</code> program.
+            <ul>
+                <li>If you don't have stored the credentials, run e.g. <code>svn info https://svnserver/repo</code> and it will tell you the realm when asking you to enter a password, e.g.: <em>Authentication realm: &lt;svn://svnserver:3690&gt; VisualSVN Server</em>.</li>
+                <li>If you have already stored the credentials to access the repository, look for the realm name in one of the files in <code>~/.subversion/auth/svn/simple</code>; it will be two lines below the line <code>svn:realmstring</code></li>
+            </ul>
+        </li>
+    </ul>
+    <p>Make sure to enter the realm <em>exactly</em> as shown, starting with a <code>&lt;</code>.
 </div>


### PR DESCRIPTION
- Made link visible: `f:entry` has the automatic help linking only if it has the `field` attribute.
- Better documentation for this option

---

I'd appreciate if someone could review the new help text, as I know Subversion primarily as a user.
