### PR TITLE
[FIXED JENKINS-6746] Updated to add setting of SVN_MAX_REVISION env

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -716,6 +716,11 @@ public class SubversionSCM extends SCM implements Serializable {
                 }
             }
 
+            // get the maximum revision which attempts to resolve JENKINS-6746
+            Long maxrev = new Long(0);
+            for (Long rev : revisions.values()) if (rev>maxrev) maxrev=rev;
+            env.put("SVN_MAX_REVISION",maxrev.toString());
+
         } catch (IOException e) {
             LOGGER.log(WARNING, "error building environment variables", e);
         }

--- a/src/test/java/hudson/scm/SubversionSCMUnitTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMUnitTest.java
@@ -102,7 +102,31 @@ public class SubversionSCMUnitTest {
         assertThat(envVars.get("SVN_URL_2"), is("/remotepath2"));
         assertThat(envVars.get("SVN_REVISION_2"), is("42"));
     }
-    
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldSetEnvironmentVariablesMaximumRevision() throws IOException {
+        // GIVEN an scm with a 2 module locations
+        SubversionSCM scm = mockSCMForBuildEnvVars();
+
+        ModuleLocation[] singleLocation = new ModuleLocation[] {new ModuleLocation("/remotepath", "")};
+        when(scm.getLocations(any(EnvVars.class), any(AbstractBuild.class))).thenReturn(singleLocation);
+
+        Map<String, Long> revisions = new HashMap<String, Long>();
+        revisions.put("/remotepath", 4711L);
+        revisions.put("/remotepath2", 42L);
+        revisions.put("/remotepath3", 9920L);
+        when(scm.parseSvnRevisionFile(any(AbstractBuild.class))).thenReturn(revisions);
+
+        // WHEN envVars are build
+        AbstractBuild<?,?> build = mock(AbstractBuild.class);
+        Map<String, String> envVars = new HashMap<String, String>();
+        scm.buildEnvVars(build, envVars);
+
+        // THEN: we have the SVN_MAX_REVISION var
+        assertThat(envVars.get("SVN_MAX_REVISION"), is("9920"));
+    }
+
     private SubversionSCM mockSCMForBuildEnvVars() {
         SubversionSCM scm = mock(SubversionSCM.class);
         doCallRealMethod().when(scm).buildEnvVars(any(AbstractBuild.class), anyMapOf(String.class, String.class));


### PR DESCRIPTION
As per JENKINS-6746, the revision returned in SVN_REVISION is the revision from trunk but not the "current revision". This change sets a new "SVN_MAX_REVISION" environmental variable to be the value of the "current revision" (a maximum of any revisions involved in the repository including any externals). This allows, for example, the setting of the build number to be the current revision so that it is unique if externals, for example, are updated but not trunk.

One thing to note is that if you have multiple SVN locations (different checkouts in the project) then as there is no way to differentiate in "revisions.txt" between these locations so this variable is set to the maximum revision present across all checked-out SVN repositories.
