### PR TITLE
Avoid NullPointerException on FishEye CR3.1.5 FE3.1.5 (20131030082910 20...

### DIFF
--- a/src/main/java/hudson/scm/browsers/FishEyeSVN.java
+++ b/src/main/java/hudson/scm/browsers/FishEyeSVN.java
@@ -87,7 +87,8 @@ public class FishEyeSVN extends SubversionRepositoryBrowser {
         if(path.getEditType()!= EditType.EDIT)
             return null;    // no diff if this is not an edit change
         int r = path.getLogEntry().getRevision();
-        return new URL(url, getPath(path)+String.format("?r1=%d&r2=%d",r-1,r));
+        // Add to aguments r2 only
+        return new URL(url, getPath(path)+String.format("?r2=%d",r));
     }
 
     @Override


### PR DESCRIPTION
If we using url http://jira/browse/<repo>/<file>?r1=50647&r2=50648 we get NullPointerException on FishEye CR3.1.5 FE3.1.5 (20131030082910 2013-10-30)
For http://jira/browse/<repo>/<file>?r2=50648 we get expected result, no error.
