### PR TITLE
[FIXED JENKINS-18099] Fix global revprop exclusion option

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -165,6 +165,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Chmod;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -2147,6 +2149,11 @@ public class SubversionSCM extends SCM implements Serializable {
 
         public String getDisplayName() {
             return "Subversion";
+        }
+
+        @Restricted(NoExternalUse.class)
+        void setGlobalExcludedRevprop(String revprop) {
+            globalExcludedRevprop = revprop;
         }
 
         public String getGlobalExcludedRevprop() {


### PR DESCRIPTION
Call to `getExcludedRevpropNormalized` was originally replaced by a call to the similarly named `getExcludedRevprop` in 72be6320a61f79ec329e0f42b496dbac8fff1644, later the now obsolete private method was removed in c44946369dd0cdfe391bc6bdb17d37cba894b6df.

This change restores the old behavior of using the global exclusion revprop unless a project-specific one is defined.
