### PR TITLE
JENKINS-22742 : Be sure that file paths used in tests are plateform-inde...

### DIFF
--- a/src/test/java/hudson/scm/SubversionSCMUnitTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMUnitTest.java
@@ -42,7 +42,9 @@ public class SubversionSCMUnitTest {
         
         FilePath resolvedRoot = scm._getModuleRoot(root, "$BRANCH/someMorePath", envVars);
 
-        String expected = String.format("root%stest/someMorePath", System.getProperty("file.separator"));
+        // Be sure that paths is plateform independant.
+        String fileSeparator = System.getProperty("file.separator");
+        String expected = String.format("root%stest%ssomeMorePath", fileSeparator, fileSeparator);
 
         Assert.assertEquals(expected, resolvedRoot.getRemote());
     }


### PR DESCRIPTION
Use System file separator property for file paths in tests so it run without errors on all plateforms.
