### PR TITLE
[JENKINS-22859] Don't fail revprop validation as easily

### DIFF
--- a/src/main/resources/hudson/scm/SubversionSCM/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/config.jelly
@@ -51,7 +51,7 @@ THE SOFTWARE.
         <f:textarea />
     </f:entry>
     <f:entry title="${%Exclusion revprop name}" field="excludedRevprop">
-        <f:textbox checkUrl="'descriptorByName/hudson.scm.SubversionSCM/checkRevisionPropertiesSupported?value='+toValue(document.getElementById('svn.remote.loc'))+'&amp;credentialsId='+toValue(document.getElementById('svn.remote.cred'))"/>
+        <f:textbox checkUrl="'descriptorByName/hudson.scm.SubversionSCM/checkRevisionPropertiesSupported?value='+toValue(document.getElementById('svn.remote.loc'))+'&amp;credentialsId='+toValue(document.getElementById('svn.remote.cred'))+'&amp;excludedRevprop='+toValue(this)"/>
     </f:entry>
     <f:entry title="${%Filter changelog}" field="filterChangelog">
         <f:checkbox />


### PR DESCRIPTION
This does not _fix_ the issue (I don't know how), but it makes it far less likely to occur.

---

Only print an error if both of the following are false:
- Field is empty (option 'exclusion revprop' unused)
- Error is authentication failure (there's other fields for that)

The first is a bit shaky due to the global exclusion revprop feature,
but chances are you're not going to see that 'not supported' error
anyway when not explicitly using a per-project setting.
