### PR TITLE
[FIXED JENKINS-22930] Renamed the tag on the Parameter History page from

### DIFF
--- a/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterValue/value.jelly
+++ b/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterValue/value.jelly
@@ -25,9 +25,6 @@
 
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${it.name}">
-        <f:textbox name="tagsDir" value="${it.tagsDir}" />
-    </f:entry>
-    <f:entry title="${%Tag}">
         <f:textbox name="tag" value="${it.tag}" />
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterValue/value.jelly
+++ b/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterValue/value.jelly
@@ -24,7 +24,7 @@
   -->
 
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry title="${%Repository URL}">
+    <f:entry title="${it.name}">
         <f:textbox name="tagsDir" value="${it.tagsDir}" />
     </f:entry>
     <f:entry title="${%Tag}">

--- a/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterValue/value.jelly
+++ b/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterValue/value.jelly
@@ -12,7 +12,7 @@
   - furnished to do so, subject to the following conditions:
   -
   - The above copyright notice and this permission notice shall be included in
-  - all copies or substantial portions of the Software.
+  - all copies or substantial portions of the Software. 
   -
   - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-22930

"Repository URL" to the actual name of the build parameter.
