### PR TITLE
[FIX JENKINS-23007] Consider environment when polling.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.489</version>
+    <version>1.509</version>
   </parent>
 
   <artifactId>subversion</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.466</version>
+    <version>1.489</version>
   </parent>
 
   <artifactId>subversion</artifactId>

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -1351,9 +1351,8 @@ public class SubversionSCM extends SCM implements Serializable {
 
         AbstractBuild<?,?> lastCompletedBuild = project.getLastCompletedBuild();
 
-        EnvVars env = null;
         if (lastCompletedBuild!=null) {
-            env = lastCompletedBuild.getEnvironment(listener);
+            EnvVars env = lastCompletedBuild.getEnvironment(listener);
             EnvVarsUtils.overrideAll(env, lastCompletedBuild.getBuildVariables());
             if (repositoryLocationsNoLongerExist(lastCompletedBuild, listener, env)) {
                 // Disable this project, see HUDSON-763
@@ -1400,7 +1399,7 @@ public class SubversionSCM extends SCM implements Serializable {
 
         final Map<String,ISVNAuthenticationProvider> authProviders = new LinkedHashMap<String,
                 ISVNAuthenticationProvider>();
-        for (ModuleLocation loc: getLocations(env, lastCompletedBuild)) {
+        for (ModuleLocation loc: getLocations(project.getEnvironment(n, listener), null)) {
             String url;
             try {
                 url = loc.getSVNURL().toDecodedString();

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -1351,8 +1351,9 @@ public class SubversionSCM extends SCM implements Serializable {
 
         AbstractBuild<?,?> lastCompletedBuild = project.getLastCompletedBuild();
 
+        EnvVars env = null;
         if (lastCompletedBuild!=null) {
-            EnvVars env = lastCompletedBuild.getEnvironment(listener);
+            env = lastCompletedBuild.getEnvironment(listener);
             EnvVarsUtils.overrideAll(env, lastCompletedBuild.getBuildVariables());
             if (repositoryLocationsNoLongerExist(lastCompletedBuild, listener, env)) {
                 // Disable this project, see HUDSON-763
@@ -1399,7 +1400,7 @@ public class SubversionSCM extends SCM implements Serializable {
 
         final Map<String,ISVNAuthenticationProvider> authProviders = new LinkedHashMap<String,
                 ISVNAuthenticationProvider>();
-        for (ModuleLocation loc: getLocations()) {
+        for (ModuleLocation loc: getLocations(env, lastCompletedBuild)) {
             String url;
             try {
                 url = loc.getSVNURL().toDecodedString();

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -90,6 +90,7 @@ import java.util.LinkedHashSet;
 import java.util.WeakHashMap;
 
 import hudson.security.ACL;
+import hudson.slaves.NodeProperty;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import jenkins.model.Jenkins.MasterComputer;
@@ -1391,9 +1392,12 @@ public class SubversionSCM extends SCM implements Serializable {
                 if (c!=null)    ch = c.getChannel();
             }
         }
-        if (ch==null)   ch= MasterComputer.localChannel;
+        if (ch==null) {
+            ch = MasterComputer.localChannel;
+            n = Jenkins.getInstance();
+        }
 
-        final String nodeName = n!=null ? n.getNodeName() : "master";
+        final String nodeName = n!=Jenkins.getInstance() ? n.getNodeName() : "master";
 
         final SVNLogHandler logHandler = new SVNLogHandler(createSVNLogFilter(), listener);
 


### PR DESCRIPTION
Otherwise, the credentials for locations with variables in their URL
aren't considered, requiring a fallback to Additional Credentials.