### PR TITLE
Show links to model object in polling log

### DIFF
--- a/src/main/java/hudson/scm/CompareAgainstBaselineCallable.java
+++ b/src/main/java/hudson/scm/CompareAgainstBaselineCallable.java
@@ -1,6 +1,8 @@
 package hudson.scm;
 
+import hudson.console.ModelHyperlinkNote;
 import hudson.model.Hudson;
+import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.remoting.DelegatingCallable;
 import hudson.scm.PollingResult.Change;
@@ -14,6 +16,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import jenkins.model.Jenkins;
 import org.tmatesoft.svn.core.SVNException;
 import org.tmatesoft.svn.core.SVNURL;
 import org.tmatesoft.svn.core.auth.ISVNAuthenticationProvider;
@@ -54,7 +57,9 @@ final class CompareAgainstBaselineCallable implements DelegatingCallable<Polling
      * so
      */
     public PollingResult call() throws IOException {
-        listener.getLogger().println("Received SCM poll call on " + nodeName + " for " + projectName + " on " + DateFormat.getDateTimeInstance().format(new Date()) );
+        String nodeLink = ModelHyperlinkNote.encodeTo("".equals(nodeName) ? ((Node) Jenkins.getInstance()) : Jenkins.getInstance().getNode(nodeName));
+        String projectLink = ModelHyperlinkNote.encodeTo(Jenkins.getInstance().getItemByFullName(projectName));
+        listener.getLogger().println("Received SCM poll call on " + nodeLink + " for " + projectLink + " on " + DateFormat.getDateTimeInstance().format(new Date()) );
         final Map<String,Long> revs = new HashMap<String,Long>();
         boolean changes = false;
         boolean significantChanges = false;

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -1393,7 +1393,7 @@ public class SubversionSCM extends SCM implements Serializable {
         }
         if (ch==null)   ch= MasterComputer.localChannel;
 
-        final String nodeName = n!=null ? n.getNodeName() : "master";
+        final String nodeName = n!=null ? n.getNodeName() : "";
 
         final SVNLogHandler logHandler = new SVNLogHandler(createSVNLogFilter(), listener);
 
@@ -1412,7 +1412,7 @@ public class SubversionSCM extends SCM implements Serializable {
         final ISVNAuthenticationProvider defaultAuthProvider = createAuthenticationProvider(project, null);
 
         // figure out the remote revisions
-        return ch.call(new CompareAgainstBaselineCallable(baseline, logHandler, project.getName(), listener, defaultAuthProvider, authProviders, nodeName));
+        return ch.call(new CompareAgainstBaselineCallable(baseline, logHandler, project.getFullName(), listener, defaultAuthProvider, authProviders, nodeName));
     }
 
     public SVNLogFilter createSVNLogFilter() {


### PR DESCRIPTION
Use the full name of the project. Link the node and (somewhat redundantly) the project from the polling log.
