### PR TITLE
[FIXED JENKINS-23498] - A new option, which disables the changelog calculation

### DIFF
--- a/src/main/resources/hudson/scm/SubversionSCM/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/config.jelly
@@ -53,6 +53,9 @@ THE SOFTWARE.
     <f:entry title="${%Exclusion revprop name}" field="excludedRevprop">
         <f:textbox checkUrl="'descriptorByName/hudson.scm.SubversionSCM/checkRevisionPropertiesSupported?value='+toValue(document.getElementById('svn.remote.loc'))+'&amp;credentialsId='+toValue(document.getElementById('svn.remote.cred'))+'&amp;excludedRevprop='+toValue(this)"/>
     </f:entry>
+    <f:entry title="${%Report changelog}" field="calculateChangelog">
+        <f:checkbox default="true"/>
+    </f:entry>
     <f:entry title="${%Filter changelog}" field="filterChangelog">
         <f:checkbox />
     </f:entry>

--- a/src/main/resources/hudson/scm/SubversionSCM/help-calculateChangelog.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-calculateChangelog.html
@@ -1,0 +1,8 @@
+<div>
+    Disables the generation of SVN changelogs.<p/>
+    
+    Sometimes the SVN checkout and changelog generation procedures take much time 
+    due to the big number of <b>svn:external</b> dependencies.
+    This option can be used to temporarily disable the calculation of changelogs
+    in such case (e.g. for the job development purposes).
+</div>

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -864,12 +864,32 @@ public class SubversionSCMTest extends AbstractSubversionTest {
     private void verifyChangelogFilter(boolean shouldFilterLog) throws Exception,
             MalformedURLException, IOException, InterruptedException,
             ExecutionException {
-          File repo = new CopyExisting(getClass().getResource("JENKINS-10449.zip")).allocate();
+        String projectName = String.format("testFilterChangelog-%s", shouldFilterLog);   
+        
+        File repo = new CopyExisting(getClass().getResource("JENKINS-10449.zip")).allocate();
           SubversionSCM scm = new SubversionSCM(ModuleLocation.parse(new String[]{"file://" + repo.toURI().toURL().getPath()},
                                                                      new String[]{"."},null,null),
                                                 new UpdateUpdater(), null, "/z.*", "", "", "", "", false, shouldFilterLog, null);
+          
+          @SuppressWarnings("unchecked")
+          ChangeLogSet<Entry> cls = generateChangeLogForSCM(projectName, scm);
+          
+          boolean ignored = true, included = false;
+          for (Entry e : cls) {
+              Collection<String> paths = e.getAffectedPaths();
+              if (paths.contains("/z/q"))
+                  ignored = false;
+              if (paths.contains("/foo"))
+                  included = true;
+          }
 
-          FreeStyleProject p = createFreeStyleProject(String.format("testFilterChangelog-%s", shouldFilterLog));
+          boolean result = ignored && included;
+          assertTrue("Changelog included or excluded entries it shouldn't have.", shouldFilterLog? result : !result);
+    }
+    
+    private ChangeLogSet generateChangeLogForSCM(String projectName, SubversionSCM scm) 
+            throws IOException, InterruptedException, Exception  {
+        FreeStyleProject p = createFreeStyleProject(projectName);
           p.setScm(scm);
           assertBuildStatusSuccess(p.scheduleBuild2(0).get());
 
@@ -889,19 +909,24 @@ public class SubversionSCMTest extends AbstractSubversionTest {
 
           AbstractBuild build = p.scheduleBuild2(0).get();
           assertBuildStatusSuccess(build);
-          boolean ignored = true, included = false;
-          @SuppressWarnings("unchecked")
-        ChangeLogSet<Entry> cls = build.getChangeSet();
-          for (Entry e : cls) {
-              Collection<String> paths = e.getAffectedPaths();
-              if (paths.contains("/z/q"))
-                  ignored = false;
-              if (paths.contains("/foo"))
-                  included = true;
-          }
 
-          boolean result = ignored && included;
-          assertTrue("Changelog included or excluded entries it shouldn't have.", shouldFilterLog? result : !result);
+          @SuppressWarnings("unchecked")
+          ChangeLogSet<Entry> cls = build.getChangeSet();
+          return cls;
+    }
+    
+    @Bug(23498)
+    public void testDisabledChangeLog() throws Exception  {
+        String projectName = "testDisabledChangeLog";
+        final boolean changelogEnabled = false;
+                
+        File repo = new CopyExisting(getClass().getResource("JENKINS-10449.zip")).allocate();
+        SubversionSCM scm = new SubversionSCM(ModuleLocation.parse(new String[]{"file://" + repo.toURI().toURL().getPath()},
+                new String[]{"."}, null, null),
+                new UpdateUpdater(), null, "/z.*", "", "", "", "", false, changelogEnabled, false, null);
+        @SuppressWarnings("unchecked")
+        ChangeLogSet<Entry> cls = generateChangeLogForSCM(projectName, scm);
+        assertTrue("The changelog should be empty", cls.isEmptySet());
     }
     
     /**


### PR DESCRIPTION
Sometimes the SVN checkout and changelog generation procedures take much time due to the big number of <code>svn:external</code> dependencies.

Our use-case:
- checkout = 10min
- changelog calculation = 15min

The proposed option can be used to temporarily disable the calculation of changelogs in such case (e.g. for the job development purposes).
