### PR TITLE
[FIXED JENKINS-24341] - Check if the project can be disabled before the disabling

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -889,7 +889,7 @@ public class SubversionSCM extends SCM implements Serializable {
                 // see http://www.nabble.com/Should-Hudson-have-an-option-for-a-content-fingerprint--td24022683.html
 
                 listener.getLogger().println("One or more repository locations do not exist anymore for " + build.getParent().getName() + ", project will be disabled.");
-                ((AbstractBuild) build).getProject().makeDisabled(true);
+                disableProject(((AbstractBuild) build).getProject(), listener);
                 return null;
             }
         }
@@ -1353,7 +1353,7 @@ public class SubversionSCM extends SCM implements Serializable {
                 // Disable this project, see HUDSON-763
                 listener.getLogger().println(
                         Messages.SubversionSCM_pollChanges_locationsNoLongerExist(project));
-                ((AbstractProject) project).makeDisabled(true);
+                disableProject((AbstractProject) project, listener);              
                 return NO_CHANGES;
             }
 
@@ -2537,6 +2537,22 @@ public class SubversionSCM extends SCM implements Serializable {
                 LOGGER.log(FINE, "Location check failed",e);
             }
         return false;
+    }
+    
+    /**
+     * Disables the project if it is possible and prints messages to the log.
+     * @param project Project to be disabled
+     * @param listener Logger
+     * @throws IOException Cannot disable the project
+     */
+    private void disableProject(@NonNull AbstractProject project, @NonNull TaskListener listener)
+            throws IOException {
+        if (project.supportsMakeDisabled()) {
+            project.makeDisabled(true);
+            listener.getLogger().println(Messages.SubversionSCM_disableProject_disabled());
+        } else {
+            listener.getLogger().println(Messages.SubversionSCM_disableProject_unsupported());
+        }
     }
 
     static final Pattern URL_PATTERN = Pattern.compile("(https?|svn(\\+[a-z0-9]+)?|file)://.+");

--- a/src/main/resources/hudson/scm/subversion/Messages.properties
+++ b/src/main/resources/hudson/scm/subversion/Messages.properties
@@ -68,6 +68,10 @@ SubversionSCM.pollChanges.ignoredRevision.onlydirprops=\
 SubversionSCM.pollChanges.exception=\
   Failed to check repository revision for {0}
 SubversionSCM.perJobCredentialsMigration=Migrate any legacy Subversion per-job credential stores
+SubversionSCM.disableProject.disabled=\
+  The project has been disabled
+SubversionSCM.disableProject.unsupported=\
+  The project does not support the disabling
 
 SubversionUpdateEventHandler.FetchExternal=\
   Fetching ''{0}'' at {1} into ''{2}''


### PR DESCRIPTION
The change calls the <code>AbstractProject::supportsMakeDisabled()</code> before calling <code>AbstractProject::makeDisabled()</code>
