### PR TITLE
Fixing JENKINS-24802

### DIFF
--- a/src/main/java/hudson/scm/SubversionRepositoryStatus.java
+++ b/src/main/java/hudson/scm/SubversionRepositoryStatus.java
@@ -186,7 +186,7 @@ public class SubversionRepositoryStatus extends AbstractModelObject {
 			return remoteUUID;
 		}
 
-		private boolean doModuleLocationContainsAPathFromAffectedPath(String configuredRepoFullPath, String rootRepoPath, Set<String> affectedPath) {
+		boolean doModuleLocationContainsAPathFromAffectedPath(String configuredRepoFullPath, String rootRepoPath, Set<String> affectedPath) {
 			boolean containsAnAffectedPath = false;
 
 			if( configuredRepoFullPath.startsWith(rootRepoPath) ) {

--- a/src/test/java/hudson/scm/SubversionRepositoryStatusTest.java
+++ b/src/test/java/hudson/scm/SubversionRepositoryStatusTest.java
@@ -13,11 +13,17 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.servlet.ServletException;
 
+import junit.framework.TestCase;
+
 import org.junit.Test;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.experimental.runners.Enclosed;
 import org.jvnet.hudson.test.Bug;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -25,6 +31,7 @@ import org.kohsuke.stapler.StaplerResponse;
 /**
  * @author kutzi
  */
+@RunWith(Enclosed.class)
 public class SubversionRepositoryStatusTest {
     
     @SuppressWarnings("rawtypes")
@@ -48,8 +55,63 @@ public class SubversionRepositoryStatusTest {
         // WHEN: post-commit hook is triggered
         listener.onNotify(UUID.randomUUID(), -1, Collections.singleton("/somepath"));
 
-        // THEN: disabled project is not considered at all
+        // EXPECT: disabled project is not considered at all
         verify(project, never()).getScm();
     }
 
+    public static class JobTriggerListenerImplTest extends TestCase {
+    	
+    	private SubversionRepositoryStatus.JobTriggerListenerImpl listener;
+    	
+    	
+    	public void setUp() {
+    		this.listener = new SubversionRepositoryStatus.JobTriggerListenerImpl();
+    	}
+    	
+    	public void tearDown() {
+    		this.listener = null;
+    	}
+    	
+    	public void testDoModuleLocationContainsAPathFromAffectedPath_affectedPathIsInConfiguredRepo() {
+    		// Given
+    		String configuredRepoFullPath = "https://svn.company.com/project/trunk";
+    		String rootRepoPath = "https://svn.company.com/project";
+
+    		Set<String> affectedPath = Collections.singleton("trunk/src/Test.java");
+
+    		// When
+    		boolean containsAffectedPath = listener.doModuleLocationContainsAPathFromAffectedPath(configuredRepoFullPath, rootRepoPath, affectedPath);
+
+    		// Expect
+    		assertTrue("affected path should be true", containsAffectedPath);        
+    	}
+    	
+    	public void testDoModuleLocationContainsAPathFromAffectedPath_affectedPathIsNotInConfiguredRepo() {
+    		// Given
+    		String configuredRepoFullPath = "https://svn.company.com/project/trunk";
+    		String rootRepoPath = "https://svn.company.com/project";
+
+    		Set<String> affectedPath = Collections.singleton("tags/src/");
+
+    		// When
+    		boolean containsAffectedPath = listener.doModuleLocationContainsAPathFromAffectedPath(configuredRepoFullPath, rootRepoPath, affectedPath);
+
+    		// Expect
+    		assertFalse("affected path should be false", containsAffectedPath);        
+    	}
+    	
+    	public void testDoModuleLocationContainsAPathFromAffectedPath_affectedPathIsNotInSameRepo() {
+    		// Given
+    		String configuredRepoFullPath = "https://svn.company.com/project/trunk";
+    		String rootRepoPath = "https://svn.company.com/projecttwo";
+
+    		Set<String> affectedPath = Collections.singleton("trunk/src/Test.java");
+
+    		// When
+    		boolean containsAffectedPath = listener.doModuleLocationContainsAPathFromAffectedPath(configuredRepoFullPath, rootRepoPath, affectedPath);
+
+    		// Expect
+    		assertFalse("affected path should be false", containsAffectedPath);        
+    	}
+    }
 }


### PR DESCRIPTION
Corrected issue explained in https://issues.jenkins-ci.org/browse/JENKINS-24802
Refactored SubversionRepositoryStatus to make onNotify method shorter and more "understandable"
Added unit tests for one refactored method
