### PR TITLE
Make SVNRevisionState public

### DIFF
--- a/src/main/java/hudson/scm/SVNRevisionState.java
+++ b/src/main/java/hudson/scm/SVNRevisionState.java
@@ -7,7 +7,7 @@ import java.util.Map;
  * {@link SCMRevisionState} for {@link SubversionSCM}. {@link Serializable} since we compute
  * this remote.
  */
-final class SVNRevisionState extends SCMRevisionState implements Serializable {
+public final class SVNRevisionState extends SCMRevisionState implements Serializable {
     /**
      * All the remote locations that we checked out. This includes those that are specified
      * explicitly via {@link SubversionSCM#getLocations()} as well as those that


### PR DESCRIPTION
Required so another plugin can retrieve the built revision. Typical use case is svnmerge-plugin which has to merge built revision to upstream branch
