### PR TITLE
Exporting new SVN_REVISION_HIGHEST for projects with multiple svn modules

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -677,7 +677,7 @@ public class SubversionSCM extends SCM implements Serializable {
         try {
             Map<String,Long> revisions = parseSvnRevisionFile(build);
             Set<String> knownURLs = revisions.keySet();
-	    Long revHighest = 0;
+	    Long revHighest = new Long(0);
             if(svnLocations.length==1) {
                 // for backwards compatibility if there's only a single modulelocation, we also set
                 // SVN_REVISION and SVN_URL without '_n'
@@ -705,9 +705,7 @@ public class SubversionSCM extends SCM implements Serializable {
                     LOGGER.log(WARNING, "no revision found corresponding to {0}; known: {1}", new Object[] {url, knownURLs});
                 }
             }
-	    if (revHighest != null) {
-		env.put("SVN_REVISION_HIGHEST", revHighest.toString());
-	    }
+	    env.put("SVN_REVISION_HIGHEST", revHighest.toString());
 
         } catch (IOException e) {
             LOGGER.log(WARNING, "error building environment variables", e);

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -677,6 +677,7 @@ public class SubversionSCM extends SCM implements Serializable {
         try {
             Map<String,Long> revisions = parseSvnRevisionFile(build);
             Set<String> knownURLs = revisions.keySet();
+	    Long revHighest = 0;
             if(svnLocations.length==1) {
                 // for backwards compatibility if there's only a single modulelocation, we also set
                 // SVN_REVISION and SVN_URL without '_n'
@@ -685,6 +686,7 @@ public class SubversionSCM extends SCM implements Serializable {
                 if(rev!=null) {
                     env.put("SVN_REVISION",rev.toString());
                     env.put("SVN_URL",url);
+		    revHighest = rev;
                 } else if (!knownURLs.isEmpty()) {
                     LOGGER.log(WARNING, "no revision found corresponding to {0}; known: {1}", new Object[] {url, knownURLs});
                 }
@@ -696,10 +698,16 @@ public class SubversionSCM extends SCM implements Serializable {
                 if(rev!=null) {
                     env.put("SVN_REVISION_"+(i+1),rev.toString());
                     env.put("SVN_URL_"+(i+1),url);
+		    if (rev > revHighest) {
+			revHighest = rev;
+		    }
                 } else if (!knownURLs.isEmpty()) {
                     LOGGER.log(WARNING, "no revision found corresponding to {0}; known: {1}", new Object[] {url, knownURLs});
                 }
             }
+	    if (revHighest != null) {
+		env.put("SVN_REVISION_HIGHEST", revHighest.toString());
+	    }
 
         } catch (IOException e) {
             LOGGER.log(WARNING, "error building environment variables", e);


### PR DESCRIPTION
Objective: Be able to know whats the highest svn revision among all the svn modules contained in the project. The var name is SVN_REVISION_HIGHEST
Motivation: We need to name the final release files using the svn revision. The problem arises when the build was triggered by a change in one of the libraries. We had to find a way to list all the svn revisions for our project and choose the highest one. 
Cons: If a project is located in different svn repositories, then there's no point in comparing their revisions. This wouldn't be an issue but the SVN_REVISION_HIGHEST wouldn't be used.
