### PR TITLE
[FIXED JENKINS-26264] UpdateUpdater perform will throw an AbortException

### DIFF
--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -26,6 +26,7 @@
  */
 package hudson.scm.subversion;
 
+import hudson.AbortException;
 import hudson.Extension;
 import hudson.model.Hudson;
 import hudson.scm.SubversionSCM.External;
@@ -167,7 +168,7 @@ public class UpdateUpdater extends WorkspaceUpdater {
             } catch (SVNCancelException e) {
                 if (isAuthenticationFailedError(e)) {
                     e.printStackTrace(listener.error("Failed to check out " + location.remote));
-                    return null;
+                    throw (AbortException) new AbortException().initCause(e);
                 } else {
                     listener.error("Subversion update has been canceled");
                     throw (InterruptedException)new InterruptedException().initCause(e);


### PR DESCRIPTION
The UpdateUpdater.perform will throw an AbortException now, as suggested in [this issue description](https://issues.jenkins-ci.org/browse/JENKINS-26264)