### PR TITLE
[JENKINS-26264] Cleanup AbortException call.

### DIFF
--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -166,8 +166,8 @@ public class UpdateUpdater extends WorkspaceUpdater {
                         break;
                 }
             } catch (SVNCancelException e) {
+                e.printStackTrace(listener.getLogger());
                 if (isAuthenticationFailedError(e)) {
-                    e.printStackTrace(listener.getLogger());
                     throw new AbortException("Failed to check out " + location.remote);
                 } else {
                     listener.error("Subversion update has been canceled");

--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -167,6 +167,7 @@ public class UpdateUpdater extends WorkspaceUpdater {
                 }
             } catch (SVNCancelException e) {
                 if (isAuthenticationFailedError(e)) {
+                    e.printStackTrace(listener.getLogger());
                     throw new AbortException("Failed to check out " + location.remote);
                 } else {
                     listener.error("Subversion update has been canceled");

--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -167,8 +167,7 @@ public class UpdateUpdater extends WorkspaceUpdater {
                 }
             } catch (SVNCancelException e) {
                 if (isAuthenticationFailedError(e)) {
-                    e.printStackTrace(listener.error("Failed to check out " + location.remote));
-                    throw (AbortException) new AbortException().initCause(e);
+                    throw new AbortException("Failed to check out " + location.remote);
                 } else {
                     listener.error("Subversion update has been canceled");
                     throw (InterruptedException)new InterruptedException().initCause(e);


### PR DESCRIPTION
Cleanup `AbortException` call by removing unnecessary part. See comment https://github.com/jenkinsci/subversion-plugin/pull/106#discussion_r23236498.

@reviewbybees 