### PR TITLE
[FIXED JENKINS-26611] Restore getRevisionFile(AbstractBuild) method.

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -1302,7 +1302,15 @@ public class SubversionSCM extends SCM implements Serializable {
         return new File(build.getRootDir(),"revision.txt");
     }
 
-    
+    /**
+     * @deprecated use {@link hudson.scm.SubversionSCM#getRevisionFile(hudson.model.Run)} instead.
+     *
+     * Gets the file that stores the revision.
+     */
+    @Deprecated
+    public static File getRevisionFile(AbstractBuild build) {
+        return new File(build.getRootDir(),"revision.txt");
+    }
 
     @Override
     public SCMRevisionState calcRevisionsFromBuild(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -1309,7 +1309,7 @@ public class SubversionSCM extends SCM implements Serializable {
      */
     @Deprecated
     public static File getRevisionFile(AbstractBuild build) {
-        return new File(build.getRootDir(),"revision.txt");
+        return getRevisionFile((Run) build);
     }
 
     @Override


### PR DESCRIPTION
The `SubversionSCM.getRevisionFile(AbstractBuild)` was altered to use instead `Run`, however some plugins have not converted to using the `Run` class, so I am restoring the method and deprecating it.

@reviewbybees