### PR TITLE
[FIXED JENKINS-22112] Show commiter name on build status page

### DIFF
--- a/src/main/resources/hudson/scm/SubversionChangeLogSet/digest.jelly
+++ b/src/main/resources/hudson/scm/SubversionChangeLogSet/digest.jelly
@@ -60,7 +60,7 @@ THE SOFTWARE.
         <j:forEach var="cs" items="${it.logs}" varStatus="loop">
           <li>
             ${cs.msgAnnotated}
-            (<a href="${rootURL}/${cs.author.url}/">${cs.author}</a>/<a href="${changesBaseUrl}changes#detail${loop.index}">${%detail}</a>
+            (<a href="${changesBaseUrl}changes#detail${loop.index}">${%detail}</a>
 
             <j:set var="cslink" value="${browser.getChangeSetLink(cs)}"/>
             <j:if test="${cslink!=null}">
@@ -68,6 +68,8 @@ THE SOFTWARE.
               <a href="${cslink}">${browser.descriptor.displayName}</a>
             </j:if>
             <j:text>)</j:text>
+	    <br/>
+	    by <a href="${rootURL}/${cs.author.url}/">${cs.author}</a>
           </li>
         </j:forEach>
       </ol>

--- a/src/main/resources/hudson/scm/SubversionChangeLogSet/digest.jelly
+++ b/src/main/resources/hudson/scm/SubversionChangeLogSet/digest.jelly
@@ -60,7 +60,7 @@ THE SOFTWARE.
         <j:forEach var="cs" items="${it.logs}" varStatus="loop">
           <li>
             ${cs.msgAnnotated}
-            (<a href="${changesBaseUrl}changes#detail${loop.index}">${%detail}</a>
+            (<a href="${rootURL}/${cs.author.url}/">${cs.author}</a>/<a href="${changesBaseUrl}changes#detail${loop.index}">${%detail}</a>
 
             <j:set var="cslink" value="${browser.getChangeSetLink(cs)}"/>
             <j:if test="${cslink!=null}">


### PR DESCRIPTION
As suggested in https://issues.jenkins-ci.org/browse/JENKINS-22112
Show commiter name on build status page

@daniel-beck was wondering whether this should be shown stating that it's supposed to be a short + succinct summary of changes

I will leave the final decision to the community.
Here is the before and after:

<b>Before:</b> http://imgur.com/mEYuGgq,taNVqUL
<b>After:</b> http://imgur.com/mEYuGgq,taNVqUL#1
