### PR TITLE
[FIXED JENKINS-26668] Fixing 'Tag this build' credentials

### DIFF
--- a/src/main/java/hudson/scm/SubversionTagAction.java
+++ b/src/main/java/hudson/scm/SubversionTagAction.java
@@ -230,6 +230,9 @@ public class SubversionTagAction extends AbstractScmTagAction implements Describ
         }
 
         String credentialsId = parser.get("credentialsId");
+        if(credentialsId == null){
+            credentialsId = parser.get("_.credentialsId");
+        }
         StandardCredentials upc = null;
         if (credentialsId != null) {
             Item context = req.findAncestorObject(Item.class);


### PR DESCRIPTION
Fix for JENKINS-26668 (https://issues.jenkins-ci.org/browse/JENKINS-26668)
For some reason, credential selection dropdown name is "_.credentialsId" in the multipart data. I think it might be encoded, so the real bug is in the MultipartFormDataParser, but it's a harmless workaround and it fixes the problem.