### PR TITLE
[JENKINS-29211] E200015: ISVNAuthentication provider did not provide credentials

### DIFF
--- a/src/main/java/hudson/scm/PerJobCredentialStore.java
+++ b/src/main/java/hudson/scm/PerJobCredentialStore.java
@@ -115,16 +115,13 @@ final class PerJobCredentialStore implements Saveable, RemotableSVNAuthenticatio
         CredentialsStore store = CredentialsProvider.lookupStores(project).iterator().next();
         for (Map.Entry<String, Credential> e : credentials.entrySet()) {
             StandardCredentials credential =  descriptor.migrateCredentials(store, e.getKey(), e.getValue());
-            int i = 0;
-            boolean found = false;
             ModuleLocation[] locations = ((SubversionSCM) project.getScm()).getLocations();
-            while (i < locations.length && !found) {
+            for (int i = 0; i < locations.length; i++) {
                 try {
                     if (e.getKey().contains(locations[i].getSVNURL().getHost())) {
                         locations[i].setCredentialsId(credential.getId());
-                        found = true;
+                        break;
                     }
-                    i++;
                 } catch (SVNException ex) {
                     // Should not happen, but...
                     LOGGER.log(WARNING, "Repository location with a malformed URL: " + locations[i].remote, ex);

--- a/src/main/java/hudson/scm/PerJobCredentialStore.java
+++ b/src/main/java/hudson/scm/PerJobCredentialStore.java
@@ -4,10 +4,16 @@ import hudson.XmlFile;
 import hudson.model.AbstractProject;
 import hudson.model.Saveable;
 import hudson.remoting.Channel;
+import hudson.scm.SubversionSCM.ModuleLocation;
 import hudson.scm.SubversionSCM.DescriptorImpl.Credential;
 import hudson.scm.SubversionSCM.DescriptorImpl.RemotableSVNAuthenticationProvider;
-import jenkins.model.Jenkins;
+
+import org.tmatesoft.svn.core.SVNException;
 import org.tmatesoft.svn.core.SVNURL;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,6 +22,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.WARNING;
 
 /**
  * Persists the credential per job. This object is remotable.
@@ -105,8 +112,24 @@ final class PerJobCredentialStore implements Saveable, RemotableSVNAuthenticatio
     private static final ThreadLocal<Boolean> IS_SAVING = new ThreadLocal<Boolean>();
 
     /*package*/ void migrateCredentials(SubversionSCM.DescriptorImpl descriptor) throws IOException {
+        CredentialsStore store = CredentialsProvider.lookupStores(project).iterator().next();
         for (Map.Entry<String, Credential> e : credentials.entrySet()) {
-            descriptor.migrateCredentials(project, e.getKey(), e.getValue());
+            StandardCredentials credential =  descriptor.migrateCredentials(store, e.getKey(), e.getValue());
+            int i = 0;
+            boolean found = false;
+            ModuleLocation[] locations = ((SubversionSCM) project.getScm()).getLocations();
+            while (i < locations.length && !found) {
+                try {
+                    if (e.getKey().contains(locations[i].getSVNURL().getHost())) {
+                        locations[i].setCredentialsId(credential.getId());
+                        found = true;
+                    }
+                    i++;
+                } catch (SVNException ex) {
+                    // Should not happen, but...
+                    LOGGER.log(WARNING, "Repository location with a malformed URL: " + locations[i].remote, ex);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-29211

This pull request tries to improve the migration process that the plugin implements for upgrading repositories with an old credentials format.

Result after upgrading:

![jenkins-29211_1](https://cloud.githubusercontent.com/assets/1021745/8496470/aa4ec0aa-2175-11e5-8d82-9c2f92de115f.png)

We lose the relation between our repository and the credentials.

