### PR TITLE
[JENKINS-29492] Fix some findbugs issues

### DIFF
--- a/src/main/java/hudson/scm/RevisionParameterAction.java
+++ b/src/main/java/hudson/scm/RevisionParameterAction.java
@@ -110,10 +110,10 @@ public class RevisionParameterAction extends InvisibleAction implements Serializ
 
 	@Override
 	public String toString() {
-		String result = "[RevisionParameterAction ";
+		StringBuilder result = new StringBuilder("[RevisionParameterAction ");
 		for(SvnInfo i : revisions) {
-			result += i.url + "(" + i.revision + ") ";
+			result.append(i.url).append("(").append(i.revision).append(") ");
 		}
-		return result + "]";
+		return result.append("]").toString();
 	}
 }

--- a/src/main/java/hudson/scm/SubversionChangeLogBuilder.java
+++ b/src/main/java/hudson/scm/SubversionChangeLogBuilder.java
@@ -227,6 +227,8 @@ public final class SubversionChangeLogBuilder {
 
     private static final LocatorImpl DUMMY_LOCATOR = new LocatorImpl();
 
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "MS_SHOULD_BE_FINAL",
+    justification = "Debugging environment variable is made editable, so it can be modified through the groovy console.")
     public static boolean debug = false;
 
     static {

--- a/src/main/java/hudson/scm/SubversionChangeLogBuilder.java
+++ b/src/main/java/hudson/scm/SubversionChangeLogBuilder.java
@@ -171,9 +171,9 @@ public final class SubversionChangeLogBuilder {
 
         // handle case where previous workspace revision is newer than this revision
         if (prevRev.compareTo(thisRev) > 0) {
-        	long temp = thisRev.longValue();
-        	thisRev = new Long(prevRev.longValue());
-        	prevRev = new Long(temp);
+            long temp = thisRev;
+            thisRev = prevRev;
+            prevRev = temp;
         }
 
         logHandler.setContext(context);

--- a/src/main/java/hudson/scm/SubversionChangeLogBuilder.java
+++ b/src/main/java/hudson/scm/SubversionChangeLogBuilder.java
@@ -179,7 +179,7 @@ public final class SubversionChangeLogBuilder {
         logHandler.setContext(context);
         try {
             if(debug)
-                listener.getLogger().printf("Computing changelog of %1s from %2s to %3s\n",
+                listener.getLogger().printf("Computing changelog of %1s from %2s to %3s%n",
                         SVNURL.parseURIEncoded(url), prevRev+1, thisRev);
             svnlc.doLog(SVNURL.parseURIEncoded(url),
                         null,


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-29492

Fixing several findbugs issues:

* Use `%n` instead of `\n` to handle platform-specific line separators.
* Use `StringBuilder` for concatenating strings.
* Unnecessary unboxing of longs.
* Ignore the debugging static variable which can be mutable.

@reviewbybees 