### PR TITLE
Exclude unused subversion plugin dependency from jenkins-test-harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,10 @@ THE SOFTWARE.
           <groupId>org.jvnet.hudson.plugins</groupId>
           <artifactId>subversion</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>subversion</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>


### PR DESCRIPTION
The jenkins-test-harness dependency had an initial exclusion of the subversion plugin, however since the plugins artifact id changed an exclusion needs to be made also.