### PR TITLE
[JENKINS-26458] Guard against a workspace format of 100.

### DIFF
--- a/src/main/java/hudson/scm/SubversionWorkspaceSelector.java
+++ b/src/main/java/hudson/scm/SubversionWorkspaceSelector.java
@@ -131,5 +131,11 @@ public class SubversionWorkspaceSelector implements ISVNAdminAreaFactorySelector
      */
     public static final int WC_FORMAT_17 = ISVNWCDb.WC_FORMAT_17;
 
+    /**
+     * @deprecated Pre (non-inclusive) 2.5 the working copy format for 1.7 was 100, however
+     * that has been changed to the official {@link ISVNWCDb#WC_FORMAT_17}.
+     */
+    public static final int OLD_WC_FORMAT_17 = 100;
+
     private static final Logger LOGGER = Logger.getLogger(SubversionWorkspaceSelector.class.getName());
 }

--- a/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
+++ b/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
@@ -39,6 +39,7 @@ import org.tmatesoft.svn.core.SVNCancelException;
 import org.tmatesoft.svn.core.SVNDepth;
 import org.tmatesoft.svn.core.SVNException;
 import org.tmatesoft.svn.core.internal.util.DefaultSVNDebugLogger;
+import org.tmatesoft.svn.core.internal.wc17.db.ISVNWCDb;
 import org.tmatesoft.svn.core.internal.wc2.compat.SvnCodec;
 import org.tmatesoft.svn.core.wc.SVNRevision;
 import org.tmatesoft.svn.core.wc.SVNUpdateClient;
@@ -108,6 +109,11 @@ public class CheckoutUpdater extends WorkspaceUpdater {
                     checkout.setAllowUnversionedObstructions(true);
                     checkout.setIgnoreExternals(location.isIgnoreExternalsOption());
                     checkout.setExternalsHandler(SvnCodec.externalsHandler(svnuc.getExternalsHandler()));
+
+                    // Statement to guard against JENKINS-26458.
+                    if (SubversionWorkspaceSelector.workspaceFormat == 100) {
+                        SubversionWorkspaceSelector.workspaceFormat = ISVNWCDb.WC_FORMAT_17;
+                    }
 
                     // Workaround for SVNKIT-430 is to set the working copy format when
                     // a checkout is performed.

--- a/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
+++ b/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
@@ -111,7 +111,7 @@ public class CheckoutUpdater extends WorkspaceUpdater {
                     checkout.setExternalsHandler(SvnCodec.externalsHandler(svnuc.getExternalsHandler()));
 
                     // Statement to guard against JENKINS-26458.
-                    if (SubversionWorkspaceSelector.workspaceFormat == 100) {
+                    if (SubversionWorkspaceSelector.workspaceFormat == SubversionWorkspaceSelector.OLD_WC_FORMAT_17) {
                         SubversionWorkspaceSelector.workspaceFormat = ISVNWCDb.WC_FORMAT_17;
                     }
 

--- a/src/test/java/hudson/scm/SVNWorkingCopyTest.java
+++ b/src/test/java/hudson/scm/SVNWorkingCopyTest.java
@@ -29,6 +29,7 @@ import hudson.model.FreeStyleProject;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.scm.subversion.WorkspaceUpdater;
 import hudson.scm.subversion.WorkspaceUpdaterDescriptor;
+import org.jvnet.hudson.test.Issue;
 import org.tmatesoft.svn.core.internal.wc.SVNStatusUtil;
 import org.tmatesoft.svn.core.internal.wc.admin.*;
 import org.tmatesoft.svn.core.internal.wc17.db.ISVNWCDb;
@@ -68,6 +69,12 @@ public class SVNWorkingCopyTest extends AbstractSubversionTest {
   public void testCheckoutWorkingCopyFormat18() throws Exception {
     checkoutAndVerifyWithFormat(ISVNWCDb.WC_FORMAT_18);
   }
+
+    @Issue("JENKINS-26458")
+    public void testCheckoutWorkingCopyFormat100() throws Exception {
+        assertEquals("Working copy of 100 should checkout 1.7",
+                ISVNWCDb.WC_FORMAT_17, checkoutWithFormat(100));
+    }
 
   private void checkoutAndVerifyWithFormat(int format) throws Exception {
     assertEquals("Checkout and workspace format do not match", format, checkoutWithFormat(format));


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-26458

There are several plugins which are using an older version of the svnkit library which still use the workspace format of `100`. Since previous versions of this plugin used 100 as the workspace format this will guard against only an invalid format of `100`.