### PR TITLE
SVNRepository.getRepositoryRoot(false) can return null

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -2372,7 +2372,7 @@ public class SubversionSCM extends SCM implements Serializable {
         }
 
         public static String getRelativePath(SVNURL repoURL, SVNRepository repository) throws SVNException {
-            String repoPath = repoURL.getPath().substring(repository.getRepositoryRoot(false).getPath().length());
+            String repoPath = repoURL.getPath().substring(repository.getRepositoryRoot(true).getPath().length());
             if(!repoPath.startsWith("/"))    repoPath="/"+repoPath;
             return repoPath;
         }
@@ -2747,7 +2747,7 @@ public class SubversionSCM extends SCM implements Serializable {
                     if (r.getRepositoryUUID(false) == null)
                         r.testConnection(); // make sure values are fetched
                     repositoryUUID = UUID.fromString(r.getRepositoryUUID(false));
-                    repositoryRoot = r.getRepositoryRoot(false);
+                    repositoryRoot = r.getRepositoryRoot(true);
                 }
             }
             return repositoryUUID;
@@ -2816,7 +2816,7 @@ public class SubversionSCM extends SCM implements Serializable {
             return getRepositoryRoot(context, context.getScm());
         }
 
-        public SVNURL getRepositoryRoot(Job context, SCM scm) throws SVNException {
+        public @Nonnull SVNURL getRepositoryRoot(Job context, SCM scm) throws SVNException {
             getUUID(context, scm);
             return repositoryRoot;
         }

--- a/src/main/java/jenkins/scm/impl/subversion/SubversionSCMSource.java
+++ b/src/main/java/jenkins/scm/impl/subversion/SubversionSCMSource.java
@@ -876,7 +876,7 @@ public class SubversionSCMSource extends SCMSource {
         }
 
         public static String getRelativePath(SVNURL repoURL, SVNRepository repository) throws SVNException {
-            String repoPath = repoURL.getPath().substring(repository.getRepositoryRoot(false).getPath().length());
+            String repoPath = repoURL.getPath().substring(repository.getRepositoryRoot(true).getPath().length());
             if(!repoPath.startsWith("/"))    repoPath="/"+repoPath;
             return repoPath;
         }


### PR DESCRIPTION
While working on Subversion-based integration tests for https://github.com/jenkinsci/workflow-plugin/pull/147 I found that branch indexing would fail with the following error:

```
Indexing started at …
Started
Opening conection to file:///…reporoot/
FATAL: Failed to index
java.lang.NullPointerException
	at hudson.scm.SubversionSCM$DescriptorImpl.getRelativePath(SubversionSCM.java:2375)
	at jenkins.scm.impl.subversion.SubversionSCMSource.retrieve(SubversionSCMSource.java:218)
	at jenkins.scm.api.SCMSource.fetch(SCMSource.java:141)
	at jenkins.branch.MultiBranchProject.populateBranchItemsFromSCM(MultiBranchProject.java:727)
	at jenkins.branch.MultiBranchProject.access$500(MultiBranchProject.java:160)
	at jenkins.branch.MultiBranchProject$BranchIndexing.run(MultiBranchProject.java:1873)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:374)
Finished: FAILURE
```

Here `SVNRepository.getRepositoryRoot(false)` is being called, which does not guarantee a non-null result:

```java
public SVNURL getRepositoryRoot(boolean forceConnection) throws SVNException {
    if (forceConnection && myRepositoryRoot == null) {
        testConnection();
    }
    return myRepositoryRoot;
}
```

You need to pass `true` to force `testConnection()` to be called and thus `myRepositoryRoot` to be set.

@tfennelly claimed indexing worked for him, so there may be some specific circumstance in which this failure occurs. I suspect the difference is that I am testing against a local (`file`-protocol) repository, whereas when using HTTP(S) some other part of the code forces a connection to be made earlier. I did not try using `svnserve`.

I found three places calling `getRepositoryRoot`, all passing `false`, and all assuming that the result was nonnull. I fixed them all, though I can only verify the fix in the case mentioned in the stack trace: with that change my test passes. I believe the fix is safe, since either `myRepositoryRoot` was null, in which case the patch is needed to avoid an NPE, or it was not, in which case passing `true` has no effect.

@reviewbybees