### PR TITLE
[JENKINS-30050] Stuff related to Javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,20 +171,26 @@ THE SOFTWARE.
           <artifactId>maven-release-plugin</artifactId>
           <version>2.5.2</version>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.14.1</version>
-          <configuration>
-            <systemPropertyVariables>
-              <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
-              <java.awt.headless>true</java.awt.headless>
-            </systemPropertyVariables>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.3</version>
+        <configuration>
+          <additionalparam>-Xdoclint:none</additionalparam>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.14.1</version>
+        <configuration>
+          <systemPropertyVariables>
+            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+            <java.awt.headless>true</java.awt.headless>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
@@ -202,7 +208,6 @@ THE SOFTWARE.
         <version>3.0.1</version>
         <configuration>
           <xmlOutput>true</xmlOutput>
-          <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
           <failOnError>false</failOnError>
         </configuration>
         <executions>

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -1768,7 +1768,7 @@ public class SubversionSCM extends SCM implements Serializable {
 
             /**
              * @param kind
-             *      One of the constants defined in {@link AuthenticationManager},
+             *      One of the constants defined in {@link ISVNAuthenticationManager},
              *      indicating what subtype of {@link SVNAuthentication} is expected.
              */
             public abstract SVNAuthentication createSVNAuthentication(String kind) throws SVNException;

--- a/src/main/java/hudson/scm/subversion/UpdaterException.java
+++ b/src/main/java/hudson/scm/subversion/UpdaterException.java
@@ -1,7 +1,7 @@
 package hudson.scm.subversion;
 
 /**
- * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class UpdaterException extends RuntimeException {
 


### PR DESCRIPTION
In this PR is included:

* Javadoc Maven Plugin configured
* Some Javadoc warning solved 
* And additionally, Surefire Maven Plugin moved to `plugins` section.

Now, it is possible to cut a release using JDK8. Javadocs (by default, in JDK8) is very strict.

@reviewbybees 