### PR TITLE
[JENKINS-30197] ClassCastException when migrating credentials

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -1667,8 +1667,10 @@ public class SubversionSCM extends SCM implements Serializable {
                 File jobCredentials = new File(job.getRootDir(), "subversion.credentials");
                 if (jobCredentials.isFile()) {
                     try {
-                        new PerJobCredentialStore(job).migrateCredentials(this);
-                        job.save();
+                        if (job.getScm() instanceof SubversionSCM) {
+                            new PerJobCredentialStore(job).migrateCredentials(this);
+                            job.save();
+                        } // else: job is not using Subversion anymore
                         if (!jobCredentials.delete()) {
                             LOGGER.log(Level.WARNING, "Could not remove legacy per-job credentials store file: {0}", jobCredentials);
                             allOk = false;


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-30197

During some migrations from 1.x to 2.5.1, I've seen the following stack trace:

```
SEVERE: Failed SubversionSCM.perJobCredentialsMigration
java.lang.Error: java.lang.reflect.InvocationTargetException
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:109)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:903)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:105)
	... 8 more
Caused by: java.lang.ClassCastException: hudson.plugins.git.GitSCM cannot be cast to hudson.scm.SubversionSCM
	at hudson.scm.PerJobCredentialStore.migrateCredentials(PerJobCredentialStore.java:120)
	at hudson.scm.SubversionSCM$DescriptorImpl.migratePerJobCredentials(SubversionSCM.java:1651)
	at hudson.scm.SubversionSCM.perJobCredentialsMigration(SubversionSCM.java:1582)
	... 13 more
```

My understanding is that:

- `SubversionSCM.migratePerJobCredentials()` tries to migrate any job for which a `subversion.credentials` file was found
- `PerJobCredentialStore.migrateCredentials()` assumes that the job to migrate is actually using SVN (ie., that `getScm()` will return a `SubversionSCM` object)
- if a job used to have a Subversion repository configured, then a `subversion.credentials` file will be found, but `migrateCredentials()` will fail with `ClassCastException`

The proposed fix simply avoids calling the migration process on such jobs.
The obsolete `subversion.credentials` files found in such jobs will still be deleted, but not converted into new-style Credentials.