### PR TITLE
[JENKINS-14541] --quiet mode for svn checkout / update

### DIFF
--- a/src/main/java/hudson/scm/SubversionEventHandlerImpl.java
+++ b/src/main/java/hudson/scm/SubversionEventHandlerImpl.java
@@ -36,9 +36,12 @@ public class SubversionEventHandlerImpl extends SVNEventAdapter {
 
     protected final File baseDir;
 
-    public SubversionEventHandlerImpl(PrintStream out, File baseDir) {
+    protected final boolean quietOperation;
+
+    public SubversionEventHandlerImpl(PrintStream out, File baseDir, boolean quietOperation) {
         this.out = out;
         this.baseDir = baseDir;
+        this.quietOperation = quietOperation;
     }
 
     public void handleEvent(SVNEvent event, double progress) throws SVNException {
@@ -54,6 +57,9 @@ public class SubversionEventHandlerImpl extends SVNEventAdapter {
         }
 
         SVNEventAction action = event.getAction();
+        if (quietOperation && (action != SVNEventAction.UPDATE_COMPLETED)) {
+            return;
+        }
 
         {// commit notifications
             if (action == SVNEventAction.COMMIT_ADDED) {

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -686,6 +686,13 @@ public class SubversionSCM extends SCM implements Serializable {
     }
 
     /**
+     * Convenience method solely for testing.
+     */
+    public void setquietOperation(boolean quietOperation) {
+        this.quietOperation = quietOperation;
+    }
+
+    /**
      * Sets the <tt>SVN_REVISION_n</tt> and <tt>SVN_URL_n</tt> environment variables during the build.
      */
     @Override

--- a/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
+++ b/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
@@ -93,10 +93,10 @@ public class CheckoutUpdater extends WorkspaceUpdater {
                     String revisionName = r.getDate() != null ?
                     		fmt.format(r.getDate()) : r.toString();
                 	
-                    listener.getLogger().println("Checking out " + location.remote + " at revision " + revisionName);
+                    listener.getLogger().println("Checking out " + location.remote + " at revision " + revisionName + (quietOperation ? " --quiet" : ""));
 
                     File local = new File(ws, location.getLocalDir());
-                    SubversionUpdateEventHandler eventHandler = new SubversionUpdateEventHandler(new PrintStream(pos), externals, local, location.getLocalDir());
+                    SubversionUpdateEventHandler eventHandler = new SubversionUpdateEventHandler(new PrintStream(pos), externals, local, location.getLocalDir(), quietOperation);
                     svnuc.setEventHandler(eventHandler);
                     svnuc.setExternalsHandler(eventHandler);
                     svnuc.setIgnoreExternals(location.isIgnoreExternalsOption());

--- a/src/main/java/hudson/scm/subversion/SubversionUpdateEventHandler.java
+++ b/src/main/java/hudson/scm/subversion/SubversionUpdateEventHandler.java
@@ -62,9 +62,9 @@ final class SubversionUpdateEventHandler extends SubversionEventHandlerImpl impl
      * Relative path from the workspace root to the module root. 
      */
     private final String modulePath;
-    
-    public SubversionUpdateEventHandler(PrintStream out, List<External> externals, File moduleDir, String modulePath) {
-        super(out,moduleDir);
+
+    public SubversionUpdateEventHandler(PrintStream out, List<External> externals, File moduleDir, String modulePath, boolean quietOperation) {
+        super(out,moduleDir,quietOperation);
         this.externals = externals;
         this.modulePath = modulePath;
     }

--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -139,7 +139,7 @@ public class UpdateUpdater extends WorkspaceUpdater {
 
             try {
                 File local = new File(ws, location.getLocalDir());
-                SubversionUpdateEventHandler eventHandler = new SubversionUpdateEventHandler(listener.getLogger(), externals, local, location.getLocalDir());
+                SubversionUpdateEventHandler eventHandler = new SubversionUpdateEventHandler(listener.getLogger(), externals, local, location.getLocalDir(), quietOperation);
                 svnuc.setEventHandler(eventHandler);
                 svnuc.setExternalsHandler(eventHandler);
 
@@ -154,11 +154,11 @@ public class UpdateUpdater extends WorkspaceUpdater {
                 
                 switch (svnCommand) {
                     case UPDATE:
-                        listener.getLogger().println("Updating " + location.remote + " at revision " + revisionName);
+                        listener.getLogger().println("Updating " + location.remote + " at revision " + revisionName + (quietOperation ? " --quiet" : ""));
                         svnuc.doUpdate(local.getCanonicalFile(), r, svnDepth, true, true);
                         break;
                     case SWITCH:
-                        listener.getLogger().println("Switching to " + location.remote + " at revision " + revisionName);
+                        listener.getLogger().println("Switching to " + location.remote + " at revision " + revisionName + (quietOperation ? " --quiet" : ""));
                         svnuc.doSwitch(local.getCanonicalFile(), location.getSVNURL(), r, r, svnDepth, true, true, true);
                         break;
                     case CHECKOUT:

--- a/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
+++ b/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
@@ -134,6 +134,11 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
         public File ws;
 
         /**
+         * --quiet for subversion operations. Default = false.
+         */
+        public boolean quietOperation;
+
+        /**
          * If the build parameter is specified with specific version numbers, this field captures that. Can be null.
          */
         public RevisionParameterAction revisions;
@@ -158,6 +163,7 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
             t.location = this.location;
             t.revisions = this.revisions;
             t.ws = this.ws;
+            t.quietOperation = this.quietOperation;
 
             return t.perform();
         }

--- a/src/main/resources/hudson/scm/SubversionSCM/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/config.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
   <f:dropdownDescriptorSelector title="${%Check-out Strategy}" field="workspaceUpdater" descriptors="${descriptor.getWorkspaceUpdaterDescriptors()}"/>
 
   <f:entry title="${%Quiet check-out}" field="quietOperation">
-    <f:checkbox default="false"/>
+    <f:checkbox default="true"/>
   </f:entry>
 
   <t:listScmBrowsers name="svn.browser" />

--- a/src/main/resources/hudson/scm/SubversionSCM/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/config.jelly
@@ -33,6 +33,10 @@ THE SOFTWARE.
 
   <f:dropdownDescriptorSelector title="${%Check-out Strategy}" field="workspaceUpdater" descriptors="${descriptor.getWorkspaceUpdaterDescriptors()}"/>
 
+  <f:entry title="${%Quiet check-out}" field="quietOperation">
+    <f:checkbox default="false"/>
+  </f:entry>
+
   <t:listScmBrowsers name="svn.browser" />
   <f:advanced>
     <f:entry title="${%Ignore Property Changes on directories}" field="ignoreDirPropChanges">

--- a/src/main/resources/hudson/scm/SubversionSCM/help-quietOperation.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-quietOperation.html
@@ -1,0 +1,4 @@
+<div>
+  Mimics subversion command line "--quiet" parameter for <b>check-out / update</b> operations to help keep the output shorter.<br>
+  <i>Print nothing, or only summary information.</i>
+</div>

--- a/src/main/resources/hudson/scm/SubversionSCM/help-quietOperation_zh_TW.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-quietOperation_zh_TW.html
@@ -1,0 +1,4 @@
+<div>
+    模仿 Subversion 客户端命令 "--quiet" 選項於 <b>check-out / update</b> 子命所顯示的訊息。<br>
+    “請求客戶端在執行操作時只顯示重要信息”
+</div>

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -777,6 +777,31 @@ public class SubversionSCMTest extends AbstractSubversionTest {
     }
 
     /**
+     * Makes sure that quiet operation shows lesser output.
+     */
+    public void testQuietCheckout() throws Exception {
+        SubversionSCM local = loadSvnRepo();
+        local.setWorkspaceUpdater(new CheckoutUpdater());
+        FreeStyleProject p = createFreeStyleProject("quietOperation");
+        p.setScm(local);
+
+        local.setquietOperation(true);
+        FreeStyleBuild bQuiet = assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause()).get());
+        List<String> logsQuiet = bQuiet.getLog(LOG_LIMIT);
+        //  This line in log should end with --quiet
+        assertTrue(logsQuiet.get(4).endsWith("--quiet"));
+        assertTrue(logsQuiet.get(5).equals("At revision 1"));
+
+        local.setquietOperation(false);
+        FreeStyleBuild bVerbose = assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause()).get());
+        List<String> logsVerbose = bVerbose.getLog(LOG_LIMIT);
+        //  This line in log should NOT end with --quiet
+        assertTrue(!logsVerbose.get(4).endsWith("--quiet"));
+        assertTrue(logsVerbose.get(5).endsWith("readme.txt"));
+        assertTrue(logsVerbose.get(6).equals("At revision 1"));
+    }
+
+    /**
      * Makes sure the symbolic link is checked out correctly. There seems to be
      */
     @Bug(3904)

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -779,6 +779,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
     /**
      * Makes sure that quiet operation shows lesser output.
      */
+    @Issue("JENKINS-14541")
     public void testQuietCheckout() throws Exception {
         SubversionSCM local = loadSvnRepo();
         local.setWorkspaceUpdater(new CheckoutUpdater());
@@ -796,9 +797,11 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         FreeStyleBuild bVerbose = assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause()).get());
         List<String> logsVerbose = bVerbose.getLog(LOG_LIMIT);
         //  This line in log should NOT end with --quiet
-        assertTrue(!logsVerbose.get(4).endsWith("--quiet"));
+        assertFalse(logsVerbose.get(4).endsWith("--quiet"));
         assertTrue(logsVerbose.get(5).endsWith("readme.txt"));
         assertTrue(logsVerbose.get(6).equals("At revision 1"));
+
+        assertTrue(logsQuiet.size() < logsVerbose.size());
     }
 
     /**


### PR DESCRIPTION
Adds an option in Subversion scm config to reduce significant amount of logs produced during build when checking out / updating working copy.

Includes both English and traditional Chinese help files / descriptions.
Also added a unit test for this feature.

https://issues.jenkins-ci.org/browse/JENKINS-14541