### PR TITLE
[FIXED JENKINS-31385] Additional logs when using svn:externals is used and SVNCancelException is thrown

### DIFF
--- a/src/main/java/hudson/scm/SubversionRepositoryStatus.java
+++ b/src/main/java/hudson/scm/SubversionRepositoryStatus.java
@@ -37,6 +37,7 @@ import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
+import org.tmatesoft.svn.core.SVNCancelException;
 import org.tmatesoft.svn.core.SVNURL;
 import org.tmatesoft.svn.core.SVNException;
 
@@ -293,6 +294,8 @@ public class SubversionRepositoryStatus extends AbstractModelObject {
                     }
                     }
 
+                } catch (SVNCancelException e) {
+                    LOGGER.log(WARNING, "Failed to handle Subversion commit notification. If you are using svn:externals feature ensure that the credentials of the externals are added on the Additional Credentials field", e);
                 } catch (SVNException e) {
                     LOGGER.log(WARNING, "Failed to handle Subversion commit notification", e);
                 } catch (IOException e) {


### PR DESCRIPTION
[JENKINS-31385](https://issues.jenkins-ci.org/browse/JENKINS-31385)

If `svn:externals` is used and the user has not configured *Additional Credentials* then `SVNCancelException` is thrown. A lot of times subversion users don't know they need to configure the external credentials on `Additional Credentials` section, so it might be a good idea to catch this exception and provide some user-friendly information.

@reviewbybees @recena @christ66 