### PR TITLE
[FIXED JENKINS-31192] Fix HTTPS SSL client certificate authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,12 +91,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.tmatesoft.svnkit</groupId>
       <artifactId>svnkit</artifactId>
-      <version>1.8.6</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>trilead-ssh2</artifactId>
-      <version>build217-jenkins-7</version>
+      <version>1.8.11</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/salida
+++ b/salida
@@ -1,0 +1,261 @@
+[INFO] Scanning for projects...
+[INFO]                                                                         
+[INFO] ------------------------------------------------------------------------
+[INFO] Building Jenkins Subversion Plug-in 2.5.4-SNAPSHOT
+[INFO] ------------------------------------------------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.3:tree (default-cli) @ subversion ---
+[INFO] org.jenkins-ci.plugins:subversion:hpi:2.5.4-SNAPSHOT
+[INFO] +- org.tmatesoft.svnkit:svnkit:jar:1.8.11:compile
+[INFO] |  +- com.jcraft:jsch.agentproxy.svnkit-trilead-ssh2:jar:0.0.7:compile
+[INFO] |  |  \- com.jcraft:jsch.agentproxy.core:jar:0.0.7:compile
+[INFO] |  +- com.trilead:trilead-ssh2:jar:1.0.0-build220:compile
+[INFO] |  +- net.java.dev.jna:jna-platform:jar:4.1.0:compile
+[INFO] |  +- net.java.dev.jna:jna:jar:4.1.0:compile
+[INFO] |  +- com.jcraft:jsch.agentproxy.connector-factory:jar:0.0.7:compile
+[INFO] |  |  +- com.jcraft:jsch.agentproxy.usocket-jna:jar:0.0.7:compile
+[INFO] |  |  |  \- net.java.dev.jna:platform:jar:3.4.0:compile
+[INFO] |  |  +- com.jcraft:jsch.agentproxy.usocket-nc:jar:0.0.7:compile
+[INFO] |  |  +- com.jcraft:jsch.agentproxy.sshagent:jar:0.0.7:compile
+[INFO] |  |  \- com.jcraft:jsch.agentproxy.pageant:jar:0.0.7:compile
+[INFO] |  +- de.regnis.q.sequence:sequence-library:jar:1.0.3:compile
+[INFO] |  \- org.tmatesoft.sqljet:sqljet:jar:1.1.10:compile
+[INFO] |     \- org.antlr:antlr-runtime:jar:3.4:compile
+[INFO] +- org.jenkins-ci.plugins:mapdb-api:jar:1.0.1.0:compile
+[INFO] |  \- org.mapdb:mapdb:jar:1.0.1:compile
+[INFO] +- org.jenkins-ci.plugins:credentials:jar:1.10:compile
+[INFO] |  +- net.jcip:jcip-annotations:jar:1.0:compile
+[INFO] |  +- com.github.stephenc.findbugs:findbugs-annotations:jar:1.3.9-1:compile
+[INFO] |  \- com.google.code.findbugs:jsr305:jar:1.3.9:compile
+[INFO] +- org.jenkins-ci.plugins:ssh-credentials:jar:1.6.1:compile
+[INFO] +- org.jenkins-ci.plugins:scm-api:jar:0.2:compile
+[INFO] +- junit:junit:jar:4.11:test
+[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
+[INFO] +- org.mockito:mockito-core:jar:1.9.5:test
+[INFO] |  \- org.objenesis:objenesis:jar:1.0:test
+[INFO] +- org.powermock:powermock-module-junit4:jar:1.5:test
+[INFO] |  \- org.powermock:powermock-module-junit4-common:jar:1.5:test
+[INFO] |     +- org.powermock:powermock-core:jar:1.5:test
+[INFO] |     |  \- org.javassist:javassist:jar:3.17.1-GA:test
+[INFO] |     \- org.powermock:powermock-reflect:jar:1.5:test
+[INFO] +- org.powermock:powermock-api-mockito:jar:1.5:test
+[INFO] |  +- org.mockito:mockito-all:jar:1.9.5:test
+[INFO] |  \- org.powermock:powermock-api-support:jar:1.5:test
+[INFO] +- org.jenkins-ci.plugins:envinject:jar:1.92:test
+[INFO] |  \- org.jenkins-ci.lib:envinject-lib:jar:1.23:test
+[INFO] +- org.jenkins-ci.main:jenkins-test-harness:jar:1.568:test
+[INFO] |  +- org.jenkins-ci.main:jenkins-war:jar:war-for-test:1.568:test
+[INFO] |  |  +- org.jenkins-ci.modules:instance-identity:jar:1.4:test
+[INFO] |  |  |  \- org.bouncycastle:bcpkix-jdk15on:jar:1.47:test
+[INFO] |  |  |     \- org.bouncycastle:bcprov-jdk15on:jar:1.47:test
+[INFO] |  |  +- org.jenkins-ci.modules:ssh-cli-auth:jar:1.2:test
+[INFO] |  |  +- org.jenkins-ci.modules:slave-installer:jar:1.3:test
+[INFO] |  |  +- org.jenkins-ci.modules:windows-slave-installer:jar:1.4:test
+[INFO] |  |  +- org.jenkins-ci.modules:launchd-slave-installer:jar:1.2:test
+[INFO] |  |  +- org.jenkins-ci.modules:upstart-slave-installer:jar:1.1:test
+[INFO] |  |  +- org.jenkins-ci.modules:systemd-slave-installer:jar:1.1:test
+[INFO] |  |  \- org.slf4j:slf4j-jdk14:jar:1.7.7:test
+[INFO] |  |     \- org.slf4j:slf4j-api:jar:1.7.7:test
+[INFO] |  +- org.jenkins-ci.main:maven-plugin:jar:2.3:test
+[INFO] |  |  +- org.jenkins-ci.plugins:javadoc:jar:1.0:test
+[INFO] |  |  +- org.jenkins-ci.main.maven:maven-agent:jar:1.5:test
+[INFO] |  |  +- org.jenkins-ci.main.maven:maven-interceptor:jar:1.5:test
+[INFO] |  |  +- org.jvnet.hudson:maven2.1-interceptor:jar:1.2:test
+[INFO] |  |  +- org.jenkins-ci.main.maven:maven3-agent:jar:1.5:test
+[INFO] |  |  +- org.jenkins-ci.main.maven:maven31-agent:jar:1.5:test
+[INFO] |  |  +- org.jenkins-ci.main.maven:maven3-interceptor:jar:1.5:test
+[INFO] |  |  +- org.jenkins-ci.main.maven:maven31-interceptor:jar:1.5:test
+[INFO] |  |  +- org.jenkins-ci.main.maven:maven3-interceptor-commons:jar:1.5:test
+[INFO] |  |  +- org.apache.maven:maven-core:jar:3.1.0:test
+[INFO] |  |  |  +- org.apache.maven:maven-model:jar:3.1.0:test
+[INFO] |  |  |  +- org.apache.maven:maven-settings:jar:3.1.0:test
+[INFO] |  |  |  +- org.apache.maven:maven-settings-builder:jar:3.1.0:test
+[INFO] |  |  |  +- org.apache.maven:maven-repository-metadata:jar:3.1.0:test
+[INFO] |  |  |  +- org.apache.maven:maven-artifact:jar:3.1.0:test
+[INFO] |  |  |  +- org.apache.maven:maven-plugin-api:jar:3.1.0:test
+[INFO] |  |  |  +- org.apache.maven:maven-model-builder:jar:3.1.0:test
+[INFO] |  |  |  +- org.codehaus.plexus:plexus-interpolation:jar:1.16:test
+[INFO] |  |  |  +- org.codehaus.plexus:plexus-utils:jar:3.0.10:test
+[INFO] |  |  |  +- org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:test
+[INFO] |  |  |  \- org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3:test
+[INFO] |  |  +- org.apache.maven:maven-compat:jar:3.1.0:test
+[INFO] |  |  +- org.apache.maven:maven-aether-provider:jar:3.1.0:test
+[INFO] |  |  +- org.apache.maven:maven-embedder:jar:3.1.0:test
+[INFO] |  |  |  +- org.sonatype.plexus:plexus-cipher:jar:1.7:test
+[INFO] |  |  |  \- commons-cli:commons-cli:jar:1.2:test
+[INFO] |  |  +- org.eclipse.aether:aether-api:jar:0.9.0.M3:test
+[INFO] |  |  +- org.eclipse.aether:aether-impl:jar:0.9.0.M3:test
+[INFO] |  |  +- org.eclipse.aether:aether-spi:jar:0.9.0.M3:test
+[INFO] |  |  +- org.eclipse.aether:aether-util:jar:0.9.0.M3:test
+[INFO] |  |  +- org.eclipse.aether:aether-transport-wagon:jar:0.9.0.M3:test
+[INFO] |  |  +- org.eclipse.sisu:org.eclipse.sisu.plexus:jar:0.0.0.M5:test
+[INFO] |  |  |  +- javax.enterprise:cdi-api:jar:1.0:test
+[INFO] |  |  |  |  \- javax.annotation:jsr250-api:jar:1.0:test
+[INFO] |  |  |  \- org.eclipse.sisu:org.eclipse.sisu.inject:jar:0.0.0.M5:test
+[INFO] |  |  +- org.apache.maven.wagon:wagon-http:jar:2.4:test
+[INFO] |  |  |  \- org.apache.maven.wagon:wagon-http-shared4:jar:2.4:test
+[INFO] |  |  |     \- org.jsoup:jsoup:jar:1.7.1:test
+[INFO] |  |  +- org.apache.httpcomponents:httpclient:jar:4.2.5:test
+[INFO] |  |  +- org.apache.httpcomponents:httpcore:jar:4.2.4:test
+[INFO] |  |  +- org.apache.maven.wagon:wagon-file:jar:2.4:test
+[INFO] |  |  +- org.apache.maven.wagon:wagon-ftp:jar:2.4:test
+[INFO] |  |  |  \- commons-net:commons-net:jar:3.1:test
+[INFO] |  |  +- org.apache.maven.wagon:wagon-ssh:jar:2.4:test
+[INFO] |  |  |  +- com.jcraft:jsch:jar:0.1.44-1:test
+[INFO] |  |  |  \- org.apache.maven.wagon:wagon-ssh-common:jar:2.4:test
+[INFO] |  |  |     \- org.codehaus.plexus:plexus-interactivity-api:jar:1.0-alpha-6:test
+[INFO] |  |  +- org.apache.maven.wagon:wagon-ssh-external:jar:2.4:test
+[INFO] |  |  +- org.apache.maven.wagon:wagon-provider-api:jar:2.4:test
+[INFO] |  |  +- org.apache.maven.reporting:maven-reporting-api:jar:3.0:test
+[INFO] |  |  |  \- org.apache.maven.doxia:doxia-sink-api:jar:1.0:test
+[INFO] |  |  +- org.codehaus.plexus:plexus-classworlds:jar:2.5.1:test
+[INFO] |  |  +- org.jenkins-ci.lib:lib-jenkins-maven-artifact-manager:jar:1.2:test
+[INFO] |  |  +- org.jenkins-ci.lib:lib-jenkins-maven-embedder:jar:3.11:test
+[INFO] |  |  |  \- org.eclipse.aether:aether-connector-wagon:jar:0.9.0.M2:test
+[INFO] |  |  \- org.apache.maven.wagon:wagon-webdav-jackrabbit:jar:2.4:test
+[INFO] |  |     +- org.apache.maven.wagon:wagon-http-shared:jar:2.4:test
+[INFO] |  |     \- org.apache.jackrabbit:jackrabbit-webdav:jar:2.5.2:test
+[INFO] |  +- org.jenkins-ci.plugins:ant:jar:1.2:test
+[INFO] |  +- org.jenkins-ci.plugins:subversion:jar:1.45:test
+[INFO] |  |  \- org.jenkins-ci.svnkit:svnkit:jar:1.7.6-jenkins-1:test
+[INFO] |  +- org.jenkins-ci.plugins:mailer:jar:1.8:test
+[INFO] |  +- org.jenkins-ci.plugins:matrix-auth:jar:1.0.2:test
+[INFO] |  +- org.jenkins-ci.plugins:antisamy-markup-formatter:jar:1.0:test
+[INFO] |  |  \- org.kohsuke:owasp-html-sanitizer:jar:r88:test
+[INFO] |  +- org.jenkins-ci.plugins:matrix-project:jar:1.0-beta-1:test
+[INFO] |  +- org.mortbay.jetty:jetty:jar:6.1.26:test
+[INFO] |  |  +- org.mortbay.jetty:jetty-util:jar:6.1.26:test
+[INFO] |  |  \- org.mortbay.jetty:servlet-api:jar:2.5-20081211:test
+[INFO] |  +- org.jenkins-ci:test-annotations:jar:1.1:test
+[INFO] |  +- org.jvnet.mock-javamail:mock-javamail:jar:1.7:test
+[INFO] |  +- org.hamcrest:hamcrest-library:jar:1.3:test
+[INFO] |  +- org.jenkins-ci:htmlunit:jar:2.6-jenkins-6:test
+[INFO] |  |  +- org.jvnet.hudson:htmlunit-core-js:jar:2.6-hudson-1:test
+[INFO] |  |  +- xerces:xercesImpl:jar:2.9.1:test
+[INFO] |  |  +- net.sourceforge.nekohtml:nekohtml:jar:1.9.13:test
+[INFO] |  |  \- net.sourceforge.cssparser:cssparser:jar:0.9.5:test
+[INFO] |  |     \- org.w3c.css:sac:jar:1.3:test
+[INFO] |  +- xalan:xalan:jar:2.7.1:test
+[INFO] |  |  \- xalan:serializer:jar:2.7.1:test
+[INFO] |  |     \- xml-apis:xml-apis:jar:1.3.04:test
+[INFO] |  +- org.jvnet.hudson:embedded-rhino-debugger:jar:1.2:test
+[INFO] |  +- org.jvnet.hudson:netx:jar:0.5-hudson-2:test
+[INFO] |  +- org.easymock:easymock:jar:2.4:test
+[INFO] |  +- org.netbeans.modules:org-netbeans-insane:jar:RELEASE72:test
+[INFO] |  \- org.codehaus.geb:geb-implicit-assertions:jar:0.7.2:test
+[INFO] +- org.jenkins-ci.main:jenkins-war:war:1.568:test
+[INFO] +- org.jenkins-ci.main:jenkins-core:jar:1.568:provided
+[INFO] |  +- org.jenkins-ci.main:remoting:jar:2.43:provided
+[INFO] |  |  \- org.jenkins-ci:constant-pool-scanner:jar:1.2:provided
+[INFO] |  +- org.jenkins-ci.main:cli:jar:1.568:provided
+[INFO] |  +- org.jenkins-ci:version-number:jar:1.1:provided
+[INFO] |  +- org.jenkins-ci:crypto-util:jar:1.1:provided
+[INFO] |  +- org.jvnet.hudson:jtidy:jar:4aug2000r7-dev-hudson-1:provided
+[INFO] |  +- com.google.inject:guice:jar:no_aop:4.0-beta:provided
+[INFO] |  |  +- javax.inject:javax.inject:jar:1:provided
+[INFO] |  |  \- aopalliance:aopalliance:jar:1.0:provided
+[INFO] |  +- org.jruby.ext.posix:jna-posix:jar:1.0.3:provided
+[INFO] |  +- com.github.jnr:jnr-posix:jar:3.0.1:provided
+[INFO] |  |  +- com.github.jnr:jnr-ffi:jar:1.0.7:provided
+[INFO] |  |  |  +- com.github.jnr:jffi:jar:1.2.7:provided
+[INFO] |  |  |  +- com.github.jnr:jffi:jar:native:1.2.7:provided
+[INFO] |  |  |  +- org.ow2.asm:asm:jar:4.0:provided
+[INFO] |  |  |  +- org.ow2.asm:asm-commons:jar:4.0:provided
+[INFO] |  |  |  +- org.ow2.asm:asm-analysis:jar:4.0:provided
+[INFO] |  |  |  +- org.ow2.asm:asm-tree:jar:4.0:provided
+[INFO] |  |  |  +- org.ow2.asm:asm-util:jar:4.0:provided
+[INFO] |  |  |  \- com.github.jnr:jnr-x86asm:jar:1.0.2:provided
+[INFO] |  |  \- com.github.jnr:jnr-constants:jar:0.8.5:provided
+[INFO] |  +- org.kohsuke:trilead-putty-extension:jar:1.2:provided
+[INFO] |  +- org.jenkins-ci:trilead-ssh2:jar:build217-jenkins-5:provided
+[INFO] |  +- org.kohsuke.stapler:stapler-groovy:jar:1.226:provided
+[INFO] |  |  \- org.kohsuke.stapler:stapler-jelly:jar:1.226:provided
+[INFO] |  |     +- org.jenkins-ci:commons-jelly:jar:1.1-jenkins-20120928:provided
+[INFO] |  |     \- org.jvnet.hudson.dom4j:dom4j:jar:1.6.1-hudson-3:provided
+[INFO] |  +- org.kohsuke.stapler:stapler-jrebel:jar:1.226:provided
+[INFO] |  |  \- org.kohsuke.stapler:stapler:jar:1.226:provided
+[INFO] |  |     +- javax.annotation:javax.annotation-api:jar:1.2:provided
+[INFO] |  |     +- commons-discovery:commons-discovery:jar:0.4:provided
+[INFO] |  |     +- org.jvnet:tiger-types:jar:1.3:provided
+[INFO] |  |     \- commons-fileupload:commons-fileupload:jar:1.2.1:provided
+[INFO] |  +- org.kohsuke:windows-package-checker:jar:1.0:provided
+[INFO] |  +- org.kohsuke.stapler:stapler-adjunct-zeroclipboard:jar:1.1.7-1:provided
+[INFO] |  +- org.kohsuke.stapler:stapler-adjunct-timeline:jar:1.4:provided
+[INFO] |  +- org.kohsuke.stapler:stapler-adjunct-codemirror:jar:1.3:provided
+[INFO] |  +- com.infradna.tool:bridge-method-annotation:jar:1.9:provided
+[INFO] |  +- org.kohsuke.stapler:json-lib:jar:2.4-jenkins-2:provided
+[INFO] |  |  \- net.sf.ezmorph:ezmorph:jar:1.0.6:provided
+[INFO] |  +- commons-httpclient:commons-httpclient:jar:3.1:provided
+[INFO] |  +- args4j:args4j:jar:2.0.23:provided
+[INFO] |  +- org.jenkins-ci:annotation-indexer:jar:1.7:provided
+[INFO] |  +- org.jenkins-ci:bytecode-compatibility-transformer:jar:1.5:provided
+[INFO] |  |  \- org.kohsuke:asm5:jar:5.0.1:provided
+[INFO] |  +- org.jenkins-ci:task-reactor:jar:1.4:provided
+[INFO] |  +- org.jvnet.localizer:localizer:jar:1.10:provided
+[INFO] |  +- antlr:antlr:jar:2.7.6:provided
+[INFO] |  +- org.jvnet.hudson:xstream:jar:1.4.7-jenkins-1:provided
+[INFO] |  +- jfree:jfreechart:jar:1.0.9:provided
+[INFO] |  |  \- jfree:jcommon:jar:1.0.12:provided
+[INFO] |  +- org.apache.ant:ant:jar:1.8.3:provided
+[INFO] |  |  \- org.apache.ant:ant-launcher:jar:1.8.3:provided
+[INFO] |  +- commons-io:commons-io:jar:2.4:provided
+[INFO] |  +- commons-lang:commons-lang:jar:2.6:provided
+[INFO] |  +- commons-digester:commons-digester:jar:2.1:provided
+[INFO] |  +- commons-beanutils:commons-beanutils:jar:1.8.3:provided
+[INFO] |  +- javax.mail:mail:jar:1.4.4:provided
+[INFO] |  +- org.jvnet.hudson:activation:jar:1.1.1-hudson-1:provided
+[INFO] |  +- jaxen:jaxen:jar:1.1-beta-11:provided
+[INFO] |  +- commons-jelly:commons-jelly-tags-fmt:jar:1.0:provided
+[INFO] |  +- commons-jelly:commons-jelly-tags-xml:jar:1.1:provided
+[INFO] |  +- org.jvnet.hudson:commons-jelly-tags-define:jar:1.0.1-hudson-20071021:provided
+[INFO] |  +- org.jenkins-ci:commons-jexl:jar:1.1-jenkins-20111212:provided
+[INFO] |  +- org.acegisecurity:acegi-security:jar:1.0.7:provided
+[INFO] |  |  +- org.springframework:spring-jdbc:jar:1.2.9:provided
+[INFO] |  |  |  \- org.springframework:spring-dao:jar:1.2.9:provided
+[INFO] |  |  +- oro:oro:jar:2.0.8:provided
+[INFO] |  |  \- log4j:log4j:jar:1.2.9:provided
+[INFO] |  +- org.codehaus.groovy:groovy-all:jar:1.8.9:provided
+[INFO] |  +- jline:jline:jar:0.9.94:provided
+[INFO] |  +- org.fusesource.jansi:jansi:jar:1.9:provided
+[INFO] |  +- org.springframework:spring-webmvc:jar:2.5.6.SEC03:provided
+[INFO] |  |  +- org.springframework:spring-beans:jar:2.5.6.SEC03:provided
+[INFO] |  |  +- org.springframework:spring-context:jar:2.5.6.SEC03:provided
+[INFO] |  |  +- org.springframework:spring-context-support:jar:2.5.6.SEC03:provided
+[INFO] |  |  \- org.springframework:spring-web:jar:2.5.6.SEC03:provided
+[INFO] |  +- org.springframework:spring-core:jar:2.5.6.SEC03:provided
+[INFO] |  +- org.springframework:spring-aop:jar:2.5.6.SEC03:provided
+[INFO] |  +- xpp3:xpp3:jar:1.1.4c:provided
+[INFO] |  +- javax.servlet:jstl:jar:1.1.0:provided
+[INFO] |  +- commons-logging:commons-logging:jar:1.1.3:provided
+[INFO] |  +- com.sun.xml.txw2:txw2:jar:20110809:provided
+[INFO] |  |  +- javax.xml.stream:stax-api:jar:1.0-2:provided
+[INFO] |  |  \- relaxngDatatype:relaxngDatatype:jar:20020414:provided
+[INFO] |  +- commons-collections:commons-collections:jar:3.2.1:provided
+[INFO] |  +- org.jvnet.winp:winp:jar:1.19:provided
+[INFO] |  +- org.jenkins-ci:memory-monitor:jar:1.8:provided
+[INFO] |  +- org.codehaus.woodstox:wstx-asl:jar:3.2.9:provided
+[INFO] |  |  \- stax:stax-api:jar:1.0.1:provided
+[INFO] |  +- org.jenkins-ci:jmdns:jar:3.4.0-jenkins-3:provided
+[INFO] |  +- org.kohsuke:akuma:jar:1.9:provided
+[INFO] |  +- org.kohsuke:libpam4j:jar:1.6:provided
+[INFO] |  +- org.jvnet.libzfs:libzfs:jar:0.5:provided
+[INFO] |  +- com.sun.solaris:embedded_su4j:jar:1.1:provided
+[INFO] |  +- net.java.sezpoz:sezpoz:jar:1.9:provided
+[INFO] |  +- org.kohsuke.jinterop:j-interop:jar:2.0.6-kohsuke-1:provided
+[INFO] |  |  \- org.kohsuke.jinterop:j-interopdeps:jar:2.0.6-kohsuke-1:provided
+[INFO] |  |     \- org.samba.jcifs:jcifs:jar:1.2.19:provided
+[INFO] |  +- org.jvnet.robust-http-client:robust-http-client:jar:1.2:provided
+[INFO] |  +- commons-codec:commons-codec:jar:1.8:provided
+[INFO] |  +- org.kohsuke:access-modifier-annotation:jar:1.4:provided
+[INFO] |  +- org.mindrot:jbcrypt:jar:0.3m:provided
+[INFO] |  +- com.google.guava:guava:jar:11.0.1:provided
+[INFO] |  \- com.jcraft:jzlib:jar:1.1.3-kohsuke-1:provided
+[INFO] +- javax.servlet:servlet-api:jar:2.4:provided
+[INFO] \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.9:provided
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 8.035 s
+[INFO] Finished at: 2015-10-27T17:06:12+01:00
+[INFO] Final Memory: 33M/489M
+[INFO] ------------------------------------------------------------------------

--- a/src/main/java/hudson/scm/CredentialsSVNAuthenticationProviderImpl.java
+++ b/src/main/java/hudson/scm/CredentialsSVNAuthenticationProviderImpl.java
@@ -454,9 +454,10 @@ public class CredentialsSVNAuthenticationProviderImpl implements ISVNAuthenticat
 
         public List<SVNAuthentication> build(String kind, SVNURL url) {
             if (ISVNAuthenticationManager.SSL.equals(kind)) {
-                SVNSSLAuthentication authentication =
-                        new SVNSSLAuthentication(String.valueOf(certificateFile), Scrambler.descramble(password), false, url, false);
-                authentication.setCertificatePath("dummy"); // TODO: remove this JENKINS-19175 workaround
+                SVNSSLAuthentication authentication = SVNSSLAuthentication.newInstance(
+                        certificateFile,
+                        Scrambler.descramble(password).toCharArray(),
+                        false, url, false);
                 return Collections.<SVNAuthentication>singletonList(
                         authentication);
             }

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -1993,10 +1993,10 @@ public class SubversionSCM extends SCM implements Serializable {
             public SVNAuthentication createSVNAuthentication(String kind) {
                 if(kind.equals(ISVNAuthenticationManager.SSL))
                     try {
-                        SVNSSLAuthentication authentication = new SVNSSLAuthentication(
-                                String.valueOf(Base64.decode(certificate.getPlainText().toCharArray())),
-                                Scrambler.descramble(Secret.toString(password)), false, null, false);
-                        authentication.setCertificatePath("dummy"); // TODO: remove this JENKINS-19175 workaround
+                        SVNSSLAuthentication authentication = SVNSSLAuthentication.newInstance(
+                                Base64.decode(certificate.getPlainText().toCharArray()),
+                                Scrambler.descramble(Secret.toString(password)).toCharArray(),
+                                false, null, false);
                         return authentication;
                     } catch (IOException e) {
                         throw new Error(e); // can't happen

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -3005,8 +3005,7 @@ public class SubversionSCM extends SCM implements Serializable {
                 return null;  //To change body of implemented methods use File | Settings | File Templates.
             }
 
-            public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context,
-                                                       @QueryParameter String remote) {
+            public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context, @QueryParameter String remote) {
                 if (context == null || !context.hasPermission(Item.CONFIGURE)) {
                     return new StandardListBoxModel();
                 }
@@ -3014,142 +3013,151 @@ public class SubversionSCM extends SCM implements Serializable {
             }
 
             public ListBoxModel fillCredentialsIdItems(@Nonnull Item context, String remote) {
-              List<DomainRequirement> domainRequirements;
-              if (remote == null) {
-                      domainRequirements = Collections.<DomainRequirement>emptyList();
-              } else {
-                  domainRequirements = URIRequirementBuilder.fromUri(remote.trim()).build();
-              }
-              return new StandardListBoxModel()
-                      .withEmptySelection()
-                      .withMatching(
-                              CredentialsMatchers.anyOf(
-                                      CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
-                                      CredentialsMatchers.instanceOf(StandardCertificateCredentials.class),
-                                      CredentialsMatchers.instanceOf(SSHUserPrivateKey.class)
-                              ),
-                              CredentialsProvider.lookupCredentials(StandardCredentials.class,
-                                      context,
-                                      ACL.SYSTEM,
-                                      domainRequirements)
-                      );
-          }
+                List<DomainRequirement> domainRequirements;
+                if (remote == null) {
+                    domainRequirements = Collections.<DomainRequirement>emptyList();
+                } else {
+                    domainRequirements = URIRequirementBuilder.fromUri(remote.trim()).build();
+                }
+                return new StandardListBoxModel()
+                        .withEmptySelection()
+                        .withMatching(
+                                CredentialsMatchers.anyOf(
+                                        CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
+                                        CredentialsMatchers.instanceOf(StandardCertificateCredentials.class),
+                                        CredentialsMatchers.instanceOf(SSHUserPrivateKey.class)
+                                ),
+                                CredentialsProvider.lookupCredentials(StandardCredentials.class,
+                                        context,
+                                        ACL.SYSTEM,
+                                        domainRequirements)
+                        );
+            }
 
-          /**
-           * validate the value for a remote (repository) location.
-           */
-          public FormValidation doCheckRemote(StaplerRequest req, @AncestorInPath Item context, @QueryParameter String remote) {
-              // syntax check first
-              String url = Util.fixEmptyAndTrim(remote);
-              if (url == null)
-                  return FormValidation.error(Messages.SubversionSCM_doCheckRemote_required());
+            /**
+             * Validate the value for a remote (repository) location.
+             */
+            public FormValidation doCheckRemote(StaplerRequest req, @AncestorInPath Item context,
+                    @QueryParameter String remote) {
 
-              if(descriptor().isValidateRemoteUpToVar()) {
-                  url = (url.indexOf('$') != -1) ? url.substring(0, url.indexOf('$')) : url;
-              } else {
-                  url = new EnvVars(EnvVars.masterEnvVars).expand(url);
-              }
+                // syntax check first
+                String url = Util.fixEmptyAndTrim(remote);
+                if (url == null) {
+                    return FormValidation.error(Messages.SubversionSCM_doCheckRemote_required());
+                }
 
-              if(!URL_PATTERN.matcher(url).matches())
-                  return FormValidation.errorWithMarkup(
-                      Messages.SubversionSCM_doCheckRemote_invalidUrl());
+                if (descriptor().isValidateRemoteUpToVar()) {
+                    url = (url.indexOf('$') != -1) ? url.substring(0, url.indexOf('$')) : url;
+                } else {
+                    url = new EnvVars(EnvVars.masterEnvVars).expand(url);
+                }
 
-              return FormValidation.ok();
-          }
+                if (!URL_PATTERN.matcher(url).matches()) {
+                    return FormValidation.errorWithMarkup(Messages.SubversionSCM_doCheckRemote_invalidUrl());
+                }
+                return FormValidation.ok();
+            }
 
-          /**
-           * validate the value for a remote (repository) location.
-           */
-          public FormValidation doCheckCredentialsId(StaplerRequest req, @AncestorInPath Item context, @QueryParameter String remote, @QueryParameter String value) {
-              // Test the connection only if we have job configure permission
-              if (context == null || !context.hasPermission(Item.CONFIGURE)) {
-                  return FormValidation.ok();
-              }
-              return checkCredentialsId(req, context, remote, value);
-          }
+            /**
+             * Validate the value for a remote (repository) location.
+             */
+            public FormValidation doCheckCredentialsId(StaplerRequest req, @AncestorInPath Item context,
+                    @QueryParameter String remote, @QueryParameter String value) {
 
-          /**
-           * validate the value for a remote (repository) location.
-           */
-          public FormValidation checkCredentialsId(StaplerRequest req, @Nonnull Item context, String remote, String value) {
-              // if check remote is reporting an issue then we don't need to
-              String url = Util.fixEmptyAndTrim(remote);
-              if (url == null)
-                  return FormValidation.ok();
+                // Test the connection only if we have job configure permission
+                if (context == null || !context.hasPermission(Item.CONFIGURE)) {
+                    return FormValidation.ok();
+                }
+                return checkCredentialsId(req, context, remote, value);
+            }
 
-              if(descriptor().isValidateRemoteUpToVar()) {
-                  url = (url.indexOf('$') != -1) ? url.substring(0, url.indexOf('$')) : url;
-              } else {
-                  url = new EnvVars(EnvVars.masterEnvVars).expand(url);
-              }
+            /**
+             * Validate the value for a remote (repository) location.
+             */
+            public FormValidation checkCredentialsId(StaplerRequest req, @Nonnull Item context, String remote, String value) {
+                // if check remote is reporting an issue then we don't need to
+                String url = Util.fixEmptyAndTrim(remote);
+                if (url == null) {
+                    return FormValidation.ok();
+                }
 
-              if(!URL_PATTERN.matcher(url).matches())
-                  return FormValidation.ok();
+                if (descriptor().isValidateRemoteUpToVar()) {
+                    url = (url.indexOf('$') != -1) ? url.substring(0, url.indexOf('$')) : url;
+                } else {
+                    url = new EnvVars(EnvVars.masterEnvVars).expand(url);
+                }
 
-              try {
-                  String urlWithoutRevision = SvnHelper.getUrlWithoutRevision(url);
+                if (!URL_PATTERN.matcher(url).matches()) {
+                    return FormValidation.ok();
+                }
 
-                  SVNURL repoURL = SVNURL.parseURIDecoded(urlWithoutRevision);
+                try {
+                    String urlWithoutRevision = SvnHelper.getUrlWithoutRevision(url);
 
-                  StandardCredentials credentials = lookupCredentials(context, value, repoURL);
-                  if (descriptor().checkRepositoryPath(context,repoURL, credentials)!=SVNNodeKind.NONE) {
-                      // something exists; now check revision if any
+                    SVNURL repoURL = SVNURL.parseURIDecoded(urlWithoutRevision);
 
-                      SVNRevision revision = getRevisionFromRemoteUrl(url);
-                      if (revision != null && !revision.isValid()) {
-                          return FormValidation.errorWithMarkup(Messages.SubversionSCM_doCheckRemote_invalidRevision());
-                      }
+                    StandardCredentials credentials = lookupCredentials(context, value, repoURL);
+                    if (descriptor().checkRepositoryPath(context, repoURL, credentials) != SVNNodeKind.NONE) {
+                        // something exists; now check revision if any
 
-                      return FormValidation.ok();
-                  }
+                        SVNRevision revision = getRevisionFromRemoteUrl(url);
+                        if (revision != null && !revision.isValid()) {
+                            return FormValidation.errorWithMarkup(Messages.SubversionSCM_doCheckRemote_invalidRevision());
+                        }
 
-                  SVNRepository repository = null;
-                  try {
-                      repository = descriptor().getRepository(context,repoURL, credentials, Collections.<String, Credentials>emptyMap(), null);
-                      long rev = repository.getLatestRevision();
-                      // now go back the tree and find if there's anything that exists
-                      String repoPath = descriptor().getRelativePath(repoURL, repository);
-                      String p = repoPath;
-                      while(p.length()>0) {
-                          p = SVNPathUtil.removeTail(p);
-                          if(repository.checkPath(p,rev)==SVNNodeKind.DIR) {
-                              // found a matching path
-                              List<SVNDirEntry> entries = new ArrayList<SVNDirEntry>();
-                              repository.getDir(p,rev,false,entries);
+                        return FormValidation.ok();
+                    }
 
-                              // build up the name list
-                              List<String> paths = new ArrayList<String>();
-                              for (SVNDirEntry e : entries)
-                                  if(e.getKind()==SVNNodeKind.DIR)
-                                      paths.add(e.getName());
+                    SVNRepository repository = null;
+                    try {
+                        repository = descriptor().getRepository(context, repoURL, credentials, Collections.<String,
+                                Credentials>emptyMap(), null);
+                        long rev = repository.getLatestRevision();
+                        // now go back the tree and find if there's anything that exists
+                        String repoPath = descriptor().getRelativePath(repoURL, repository);
+                        String p = repoPath;
+                        while (p.length() > 0) {
+                            p = SVNPathUtil.removeTail(p);
+                            if (repository.checkPath(p, rev) == SVNNodeKind.DIR) {
+                                // found a matching path
+                                List<SVNDirEntry> entries = new ArrayList<SVNDirEntry>();
+                                repository.getDir(p, rev, false, entries);
 
-                              String head = SVNPathUtil.head(repoPath.substring(p.length() + 1));
-                              String candidate = EditDistance.findNearest(head,paths);
+                                // build up the name list
+                                List<String> paths = new ArrayList<String>();
+                                for (SVNDirEntry e : entries) {
+                                    if (e.getKind() == SVNNodeKind.DIR) {
+                                        paths.add(e.getName());
+                                    }
+                                }
 
-                              return FormValidation.error(
-                                  Messages.SubversionSCM_doCheckRemote_badPathSuggest(p, head,
-                                      candidate != null ? "/" + candidate : ""));
-                          }
-                      }
+                                String head = SVNPathUtil.head(repoPath.substring(p.length() + 1));
+                                String candidate = EditDistance.findNearest(head, paths);
 
-                      return FormValidation.error(
-                          Messages.SubversionSCM_doCheckRemote_badPath(repoPath));
-                  } finally {
-                      if (repository != null)
-                          repository.closeSession();
-                  }
-              } catch (SVNException e) {
-                  LOGGER.log(Level.INFO, "Failed to access subversion repository "+url,e);
-                  String message = Messages.SubversionSCM_doCheckRemote_exceptionMsg1(
-                      Util.escape(url), Util.escape(e.getErrorMessage().getFullMessage()),
-                      "javascript:document.getElementById('svnerror').style.display='block';"
-                        + "document.getElementById('svnerrorlink').style.display='none';"
-                        + "return false;")
-                    + "<br/><pre id=\"svnerror\" style=\"display:none\">"
-                    + Functions.printThrowable(e) + "</pre>";
-                  return FormValidation.errorWithMarkup(message);
-              }
-          }
+                                return FormValidation.error(
+                                        Messages.SubversionSCM_doCheckRemote_badPathSuggest(p, head,
+                                                candidate != null ? "/" + candidate : ""));
+                            }
+                        }
+
+                        return FormValidation.error(Messages.SubversionSCM_doCheckRemote_badPath(repoPath));
+                    } finally {
+                        if (repository != null) {
+                            repository.closeSession();
+                        }
+                    }
+                } catch (SVNException e) {
+                    LOGGER.log(Level.INFO, "Failed to access subversion repository: " + url, e);
+                    String message = Messages.SubversionSCM_doCheckRemote_exceptionMsg1(
+                            Util.escape(url), Util.escape(e.getErrorMessage().getFullMessage()),
+                            "javascript:document.getElementById('svnerror').style.display='block';"
+                                    + "document.getElementById('svnerrorlink').style.display='none';"
+                                    + "return false;")
+                            + "<br/><pre id=\"svnerror\" style=\"display:none\">"
+                            + Functions.printThrowable(e) + "</pre>";
+                    return FormValidation.errorWithMarkup(message);
+                }
+            }
 
             /**
              * validate the value for a local location (local checkout directory).

--- a/src/test/java/hudson/scm/SubversionEnvVarsTest.java
+++ b/src/test/java/hudson/scm/SubversionEnvVarsTest.java
@@ -1,0 +1,38 @@
+package hudson.scm;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.TaskListener;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertFalse;
+
+public class SubversionEnvVarsTest {
+
+    public static String REPO_URL = "https://svn.jenkins-ci.org/${BRANCH}/jenkins/test-projects/model-maven-project";
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    /**
+     * This test aims to verify that the environment variables (from Global Properties section) are available in SCM
+     * Polling.
+     */
+    @Issue("JENKINS-31067")
+    @Test
+    public void pollingWithEnvVars() throws Exception {
+        jenkins.getInstance().getGlobalNodeProperties().add(new EnvironmentVariablesNodeProperty(new
+                EnvironmentVariablesNodeProperty.Entry("BRANCH", "trunk")));
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+
+        project.setScm(new SubversionSCM(REPO_URL));
+        jenkins.assertBuildStatusSuccess(project.scheduleBuild2(0).get());
+
+        TaskListener listener = jenkins.createTaskListener();
+        PollingResult poll = project.poll(listener);
+        assertFalse(poll.hasChanges());
+    }
+}


### PR DESCRIPTION
[JENKINS-31192](https://issues.jenkins-ci.org/browse/JENKINS-31192)

Take benefits of new SVNKit 1.8.11 SVNSSLAuthentication methods to properly support byte array PKCS#12 certificate usage.

Supersede https://github.com/jenkinsci/subversion-plugin/pull/141