### PR TITLE
[JENKINS-31192] Fix HTTPS SSL client certificate authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,12 +91,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.tmatesoft.svnkit</groupId>
       <artifactId>svnkit</artifactId>
-      <version>1.8.6</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>trilead-ssh2</artifactId>
-      <version>build217-jenkins-7</version>
+      <version>1.8.11</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/scm/CredentialsSVNAuthenticationProviderImpl.java
+++ b/src/main/java/hudson/scm/CredentialsSVNAuthenticationProviderImpl.java
@@ -454,9 +454,10 @@ public class CredentialsSVNAuthenticationProviderImpl implements ISVNAuthenticat
 
         public List<SVNAuthentication> build(String kind, SVNURL url) {
             if (ISVNAuthenticationManager.SSL.equals(kind)) {
-                SVNSSLAuthentication authentication =
-                        new SVNSSLAuthentication(String.valueOf(certificateFile), Scrambler.descramble(password), false, url, false);
-                authentication.setCertificatePath("dummy"); // TODO: remove this JENKINS-19175 workaround
+                SVNSSLAuthentication authentication = SVNSSLAuthentication.newInstance(
+                        certificateFile,
+                        Scrambler.descramble(password).toCharArray(),
+                        false, url, false);
                 return Collections.<SVNAuthentication>singletonList(
                         authentication);
             }

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -1993,10 +1993,10 @@ public class SubversionSCM extends SCM implements Serializable {
             public SVNAuthentication createSVNAuthentication(String kind) {
                 if(kind.equals(ISVNAuthenticationManager.SSL))
                     try {
-                        SVNSSLAuthentication authentication = new SVNSSLAuthentication(
-                                String.valueOf(Base64.decode(certificate.getPlainText().toCharArray())),
-                                Scrambler.descramble(Secret.toString(password)), false, null, false);
-                        authentication.setCertificatePath("dummy"); // TODO: remove this JENKINS-19175 workaround
+                        SVNSSLAuthentication authentication = SVNSSLAuthentication.newInstance(
+                                Base64.decode(certificate.getPlainText().toCharArray()),
+                                Scrambler.descramble(Secret.toString(password)).toCharArray(),
+                                false, null, false);
                         return authentication;
                     } catch (IOException e) {
                         throw new Error(e); // can't happen


### PR DESCRIPTION
[JENKINS-31192](https://issues.jenkins-ci.org/browse/JENKINS-31192)

Take benefits of new SVNKit 1.8.11 SVNSSLAuthentication methods to properly support byte array PKCS#12 certificate usage.