### PR TITLE
[JENKINS-27718] Override ParameterValue.buildEnvironment()

### DIFF
--- a/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterValue.java
+++ b/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterValue.java
@@ -28,6 +28,7 @@ package hudson.scm.listtagsparameter;
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.ParameterValue;
+import hudson.model.Run;
 import hudson.util.VariableResolver;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.export.Exported;
@@ -51,7 +52,7 @@ public class ListSubversionTagsParameterValue extends ParameterValue {
   }
 
   @Override
-  public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
+  public void buildEnvironment(Run<?,?> build, EnvVars env) {
     env.put(getName(), getTag());
   }
 


### PR DESCRIPTION
[JENKINS-27718](https://issues.jenkins-ci.org/browse/JENKINS-27718)

ParameterValue.buildEnvVars() was deprecated in Jenkins 1.344.

See:
http://javadoc.jenkins-ci.org/hudson/model/ParameterValue.html#buildEnvVars%28hudson.model.AbstractBuild,%20java.util.Map%29
and also see:
https://github.com/jenkinsci/jenkins/commit/d1b713a4d86a846af2305705e42de8f0709b19ce

This fix is needed for the workflow plugin.