### PR TITLE
[JENKINS-16711] SVNPath must be built from a decoded path

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -3092,8 +3092,8 @@ public class SubversionSCM extends SCM implements Serializable {
                     StandardCredentials credentials = lookupCredentials(context, value, repoURL);
                     SVNRepository repo = descriptor().getRepository(context, repoURL, credentials, Collections
                             .<String, Credentials>emptyMap(), null);
-                    String repoRoot = repo.getRepositoryRoot(false).toString();
-                    String repoPath = repo.getLocation().toString().substring(repoRoot.length());
+                    String repoRoot = repo.getRepositoryRoot(false).toDecodedString();
+                    String repoPath = repo.getLocation().toDecodedString().substring(repoRoot.length());
                     SVNPath path = new SVNPath(repoPath, true, true);
                     SVNNodeKind svnNodeKind = repo.checkPath(path.getTarget(), path.getPegRevision().getNumber());
                     if (svnNodeKind != SVNNodeKind.DIR) {

--- a/src/main/java/jenkins/scm/impl/subversion/SubversionSCMSource.java
+++ b/src/main/java/jenkins/scm/impl/subversion/SubversionSCMSource.java
@@ -242,7 +242,7 @@ public class SubversionSCMSource extends SCMSource {
             throws IOException {
         SVNRepositoryView repository = null;
         try {
-            listener.getLogger().println("Opening conection to " + remoteBase);
+            listener.getLogger().println("Opening connection to " + remoteBase);
             SVNURL repoURL = SVNURL.parseURIEncoded(remoteBase);
             repository = openSession(repoURL);
             String repoPath = SubversionSCM.DescriptorImpl.getRelativePath(repoURL, repository.getRepository());


### PR DESCRIPTION
[JENKINS-16711](https://issues.jenkins-ci.org/browse/JENKINS-16711)

This PR is the second part of https://github.com/jenkinsci/subversion-plugin/pull/149

Examples:
* [https://subversion.assembla.com/svn/jenkins-31937-2/project1/User Guide/](https://subversion.assembla.com/svn/jenkins-31937-2/project1/User Guide/)
* [https://subversion.assembla.com/svn/my repo/project1/User Guide/](https://subversion.assembla.com/svn/my repo/project1/User Guide/)

@reviewbybees 
