### PR TITLE
[JENKINS-16711] Encode the URLs when are shown in the logger

### DIFF
--- a/src/main/java/hudson/scm/SubversionEventHandlerImpl.java
+++ b/src/main/java/hudson/scm/SubversionEventHandlerImpl.java
@@ -57,19 +57,19 @@ public class SubversionEventHandlerImpl extends SVNEventAdapter {
 
         {// commit notifications
             if (action == SVNEventAction.COMMIT_ADDED) {
-                out.println("Adding         "+path);
+                out.println("Adding         " + path);
                 return;
             }
             if (action == SVNEventAction.COMMIT_DELETED) {
-                out.println("Deleting       "+path);
+                out.println("Deleting       " + path);
                 return;
             }
             if (action == SVNEventAction.COMMIT_MODIFIED) {
-                out.println("Sending        "+path);
+                out.println("Sending        " + path);
                 return;
             }
             if (action == SVNEventAction.COMMIT_REPLACED) {
-                out.println("Replacing      "+path);
+                out.println("Replacing      " + path);
                 return;
             }
             if (action == SVNEventAction.COMMIT_DELTA_SENT) {
@@ -100,7 +100,7 @@ public class SubversionEventHandlerImpl extends SVNEventAdapter {
                  * from the repository
                  */
                 pathChangeType = "U";
-            }else if (contentsStatus == SVNStatusType.CONFLICTED) {
+            } else if (contentsStatus == SVNStatusType.CONFLICTED) {
                 /*
                  * The file item is in  a  state  of Conflict. That is, changes
                  * received from the repository during an update, overlap  with
@@ -118,6 +118,7 @@ public class SubversionEventHandlerImpl extends SVNEventAdapter {
         } else if (action == SVNEventAction.UPDATE_COMPLETED) {
             // finished updating
             out.println("At revision " + event.getRevision());
+            out.println();
             return;
         } else if (action == SVNEventAction.ADD){
             out.println("A     " + path);


### PR DESCRIPTION
We want to avoid this:

![jenkins-16711](https://cloud.githubusercontent.com/assets/1021745/12053033/342e25a4-af15-11e5-8e52-62b29cb41f9d.png)

@reviewbybees