### PR TITLE
[JENKINS-32169] SVNRepository.getRepositoryRoot(false) can return null

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -3092,7 +3092,7 @@ public class SubversionSCM extends SCM implements Serializable {
                     StandardCredentials credentials = lookupCredentials(context, value, repoURL);
                     SVNRepository repo = descriptor().getRepository(context, repoURL, credentials, Collections
                             .<String, Credentials>emptyMap(), null);
-                    String repoRoot = repo.getRepositoryRoot(false).toDecodedString();
+                    String repoRoot = repo.getRepositoryRoot(true).toDecodedString();
                     String repoPath = repo.getLocation().toDecodedString().substring(repoRoot.length());
                     SVNPath path = new SVNPath(repoPath, true, true);
                     SVNNodeKind svnNodeKind = repo.checkPath(path.getTarget(), path.getPegRevision().getNumber());


### PR DESCRIPTION
..when one uses `svn://` and `file://` protocols.

[JENKINS-32169](https://issues.jenkins-ci.org/browse/JENKINS-32169)

PR related: https://github.com/jenkinsci/subversion-plugin/pull/129

@reviewbybees , esp @jglick 