### PR TITLE
Use the lastest changed tag as default

### DIFF
--- a/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition/config.jelly
+++ b/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition/config.jelly
@@ -40,6 +40,10 @@
     <f:entry title="${%Default value}" field="defaultValue">
         <f:textbox/>
     </f:entry> 
+    <f:entry field="useLatestTag">
+        <f:checkbox/>
+        <label class="attach-previous">${%Use latest tag}</label>
+    </f:entry>
     <f:entry title="${%Maximum tags to display}" field="maxTags">
         <f:textbox/>
     </f:entry>       

--- a/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition/help-useLatestTag.html
+++ b/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition/help-useLatestTag.html
@@ -1,0 +1,31 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2011, Manufacture Francaise des Pneumatiques Michelin, Romain Seguy
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+
+<div>
+  Check this option so that the latest tag in the tags/ subdirectory is used as default value.
+
+  <p>
+  If this option is checked, the <b>Default value</b> one won't be taken into
+  account.
+</div>


### PR DESCRIPTION
In a recent commt ([[JENKINS-14155] Automatically select the first option of tags listing…](5012326e8dc523e5e7706839b7853a86b1f3dce5)), support was added to select the latest changed tag as default value. For this to work, the repository URL (of the subversion tag parameters) must point to the tags directory (e.g. foo/tags). If you want to also include trunk and branches (i.e. setting the repository URL to foo/), you cannot benefit from the "use the latest tag" feature.

This branch extends the recent functionality, such that one can use a repository URL pointing to the top level directory (foo) while still using the latest changed tag from the tags sub directory as default.

To this end a new checkbox "Use latest tag" is added below the "Default value" text box.