### PR TITLE
[JENKINS-32747] Adapt to Plugin POM 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@ THE SOFTWARE.
   <properties>
     <jenkins.version>1.568</jenkins.version>
     <jenkins-test-harness.version>1.568</jenkins-test-harness.version>
-    <java.level>7</java.level>
+    <java.level>6</java.level>
     <java.level.test>${java.level}</java.level.test>
     <findbugs.failOnError>false</findbugs.failOnError>
     <hpi-plugin.version>1.115</hpi-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.568</version>
+    <version>2.3</version>
   </parent>
 
   <artifactId>subversion</artifactId>
@@ -37,6 +37,7 @@ THE SOFTWARE.
 
   <name>Jenkins Subversion Plug-in</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Subversion+Plugin</url>
+
   <licenses>
     <license>
       <name>MIT license</name>
@@ -57,6 +58,7 @@ THE SOFTWARE.
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>HEAD</tag>
   </scm>
+
   <distributionManagement>
     <repository>
       <id>maven.jenkins-ci.org</id>
@@ -65,8 +67,12 @@ THE SOFTWARE.
   </distributionManagement>
 
   <properties>
-    <maven-hpi-plugin.version>1.96</maven-hpi-plugin.version>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jenkins.version>1.568</jenkins.version>
+    <jenkins-test-harness.version>1.568</jenkins-test-harness.version>
+    <java.level>7</java.level>
+    <java.level.test>${java.level}</java.level.test>
+    <findbugs.failOnError>false</findbugs.failOnError>
+    <hpi-plugin.version>1.115</hpi-plugin.version>
   </properties>
 
   <repositories>
@@ -80,6 +86,7 @@ THE SOFTWARE.
       <url>http://maven.tmatesoft.com/content/repositories/releases/</url>
     </repository>
   </repositories>
+
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
@@ -145,93 +152,20 @@ THE SOFTWARE.
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-test-harness</artifactId>
-      <version>${project.parent.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jvnet.hudson.plugins</groupId>
-          <artifactId>subversion</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.2</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
-        <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.14.1</version>
-        <configuration>
-          <systemPropertyVariables>
-            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
-            <java.awt.headless>true</java.awt.headless>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
-        <version>${maven-hpi-plugin.version}</version>
+        <version>${hpi-plugin.version}</version>
         <configuration>
           <maskClasses>com.trilead.ssh2.</maskClasses>
           <systemProperties>
             <hudson.bundled.plugins>${basedir}/work/plugins/subversion.hpl</hudson.bundled.plugins>
           </systemProperties>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.2</version>
-        <configuration>
-          <xmlOutput>true</xmlOutput>
-          <failOnError>false</failOnError>
-        </configuration>
-        <executions>
-          <execution>
-            <id>findbugs</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.2</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>3.0</version>
-                </requireMavenVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@ THE SOFTWARE.
     <java.level>6</java.level>
     <java.level.test>${java.level}</java.level.test>
     <findbugs.failOnError>false</findbugs.failOnError>
-    <hpi-plugin.version>1.115</hpi-plugin.version>
   </properties>
 
   <repositories>

--- a/src/main/resources/hudson/scm/SubversionChangeLogSet/digest.jelly
+++ b/src/main/resources/hudson/scm/SubversionChangeLogSet/digest.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Displays the Subversion change log digest.

--- a/src/main/resources/hudson/scm/SubversionChangeLogSet/index.jelly
+++ b/src/main/resources/hudson/scm/SubversionChangeLogSet/index.jelly
@@ -22,9 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<!--
-  Displays the Subversion change log.
--->
+<!-- Displays the Subversion changelog -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="browser" value="${it.build.parent.scm.effectiveBrowser}"/>
 

--- a/src/main/resources/hudson/scm/SubversionMailAddressResolverImpl/global.jelly
+++ b/src/main/resources/hudson/scm/SubversionMailAddressResolverImpl/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:section title="Subversion Mail Address Resolver">
         <f:entry title="Matching rules"

--- a/src/main/resources/hudson/scm/SubversionSCM/AdditionalCredentials/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/AdditionalCredentials/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 <f:entry title="${%Realm}" field="realm">
   <f:textbox/>

--- a/src/main/resources/hudson/scm/SubversionSCM/DescriptorImpl/credentialOK.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/DescriptorImpl/credentialOK.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${%Subversion Authentication Successful}">
     <l:header />

--- a/src/main/resources/hudson/scm/SubversionSCM/DescriptorImpl/enterCredential.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/DescriptorImpl/enterCredential.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout norefresh="true" title="${%Subversion Authentication}">
     <l:header />

--- a/src/main/resources/hudson/scm/SubversionSCM/DescriptorImpl/url-help.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/DescriptorImpl/url-help.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:ajax>
     <div>

--- a/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:entry title="${%Repository URL}" field="remote" help="/scm/SubversionSCM/url-help">
     <f:textbox id="svn.remote.loc" onchange="{ /* workaround for JENKINS-19124 */

--- a/src/main/resources/hudson/scm/SubversionSCM/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:entry title="${%Modules}">
     <f:repeatableProperty field="locations" add="${%Add module...}" minimum="1"/>

--- a/src/main/resources/hudson/scm/SubversionSCM/global.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/global.jelly
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:section title="${%Subversion}">
         <f:entry title="${%Subversion Workspace Version}" help="/descriptor/hudson.scm.SubversionSCM/help/workspaceFormat">

--- a/src/main/resources/hudson/scm/SubversionTagAction/tagForm.jelly
+++ b/src/main/resources/hudson/scm/SubversionTagAction/tagForm.jelly
@@ -22,11 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<!--
-  Displays the form to choose the tag name.
-
-  This belongs to a build view.
--->
+<!-- Displays the form to choose the tag name. This belongs to a build view. -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <d:taglib uri="local">
     <d:tag name="listTags">

--- a/src/main/resources/hudson/scm/browsers/AbstractSventon/config.jelly
+++ b/src/main/resources/hudson/scm/browsers/AbstractSventon/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%URL}" field="url">
     <f:textbox />

--- a/src/main/resources/hudson/scm/browsers/Assembla/config.jelly
+++ b/src/main/resources/hudson/scm/browsers/Assembla/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="Space Name" field="spaceName">
     <f:textbox />

--- a/src/main/resources/hudson/scm/browsers/CollabNetSVN/config.jelly
+++ b/src/main/resources/hudson/scm/browsers/CollabNetSVN/config.jelly
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<!-- Configuration for CollabNet SVN browser. -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="URL" field="url">
     <f:textbox />

--- a/src/main/resources/hudson/scm/browsers/FishEyeSVN/config.jelly
+++ b/src/main/resources/hudson/scm/browsers/FishEyeSVN/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%URL}" field="url">
     <f:textbox />

--- a/src/main/resources/hudson/scm/browsers/SVNWeb/config.jelly
+++ b/src/main/resources/hudson/scm/browsers/SVNWeb/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="URL" field="url">
     <f:textbox />

--- a/src/main/resources/hudson/scm/browsers/ViewSVN/config.jelly
+++ b/src/main/resources/hudson/scm/browsers/ViewSVN/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="URL" field="url">
     <f:textbox />

--- a/src/main/resources/hudson/scm/browsers/WebSVN/config.jelly
+++ b/src/main/resources/hudson/scm/browsers/WebSVN/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="URL" field="url">
     <f:textbox />

--- a/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition/config.jelly
+++ b/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition/config.jelly
@@ -24,6 +24,7 @@
   -->
 
 <!-- this is the page fragment displayed to set up a job -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:entry title="${%Name}" field="name">
         <f:textbox/>

--- a/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition/index.jelly
+++ b/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition/index.jelly
@@ -23,6 +23,7 @@
   -->
 
 <!-- this is the page fragment displayed when triggering a new build -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
   <f:entry title="${it.name}" description="${it.description}">
     <!-- this div is required because of ParametersDefinitionProperty.java#117 -->

--- a/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterValue/value.jelly
+++ b/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterValue/value.jelly
@@ -23,6 +23,7 @@
   - THE SOFTWARE.
   -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${%Repository URL}">
         <f:textbox name="tagsDir" value="${it.tagsDir}" />

--- a/src/main/resources/hudson/scm/subversion/CheckoutUpdater/config.jelly
+++ b/src/main/resources/hudson/scm/subversion/CheckoutUpdater/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:description>
     ${%blurb}

--- a/src/main/resources/hudson/scm/subversion/UpdateUpdater/config.jelly
+++ b/src/main/resources/hudson/scm/subversion/UpdateUpdater/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:description>
     ${%blurb}

--- a/src/main/resources/hudson/scm/subversion/UpdateWithCleanUpdater/config.jelly
+++ b/src/main/resources/hudson/scm/subversion/UpdateWithCleanUpdater/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:description>
     ${%blurb}

--- a/src/main/resources/hudson/scm/subversion/UpdateWithRevertUpdater/config.jelly
+++ b/src/main/resources/hudson/scm/subversion/UpdateWithRevertUpdater/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:description>
     ${%blurb}

--- a/src/main/resources/hudson/scm/subversion/WorkspaceUpdater/config.jelly
+++ b/src/main/resources/hudson/scm/subversion/WorkspaceUpdater/config.jelly
@@ -1,2 +1,3 @@
 <!-- empty config page -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" />

--- a/src/main/resources/hudson/scm/subversion/enterCredential.jelly
+++ b/src/main/resources/hudson/scm/subversion/enterCredential.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <st:documentation>
     UI fragment for asking for a credential.

--- a/src/main/resources/jenkins/scm/impl/subversion/SubversionSCMSource/config-detail.jelly
+++ b/src/main/resources/jenkins/scm/impl/subversion/SubversionSCMSource/config-detail.jelly
@@ -22,6 +22,7 @@
  ~ THE SOFTWARE.
  -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Project Repository Base}" field="remoteBase">
     <f:textbox/>


### PR DESCRIPTION
[JENKINS-32747](https://issues.jenkins-ci.org/browse/JENKINS-32747)

As part of this PR these tests should be solved:

```
hudson/scm/SubversionSCM/DescriptorImpl/url-help.jelly(org.jvnet.hudson.test.JellyTestSuiteBuilder$JellyCheck)  Time elapsed: 0.005 sec  <<< FAILURE!
java.lang.AssertionError: <?jelly escape-by-default='true'?> is missing
        at org.jvnet.hudson.test.JellyTestSuiteBuilder$JellyCheck.runTest(JellyTestSuiteBuilder.java:98)
```

@reviewbybees 