### PR TITLE
Fix bug where having branch wildcards at different depths would cause ArrayBoundExceptions

### DIFF
--- a/src/main/java/jenkins/scm/impl/subversion/SubversionSCMSource.java
+++ b/src/main/java/jenkins/scm/impl/subversion/SubversionSCMSource.java
@@ -293,6 +293,9 @@ public class SubversionSCMSource extends SCMSource {
         }
         for (Map.Entry<List<String>, SortedSet<List<String>>> entry : includePaths.entrySet()) {
             for (List<String> path : entry.getValue()) {
+                if (prefix.size() >= path.size()) {
+                    continue;
+                }
                 String name = path.get(prefix.size());
                 SVNRepositoryView.ChildEntry[] children = node.getChildren().clone();
                 Arrays.sort(children, new Comparator<SVNRepositoryView.ChildEntry>() {


### PR DESCRIPTION
An example use case of this is the Jenkins Multibranch Pipeline to try and find stuff to build in a chaotic monorepo. I set "Include branches" to: trunk,branches/*,branches/*/*,branches/*/*/*,branches/*/*/*/*,tags/* and got an indexing exception. This patch seems to fix it.