### PR TITLE
[JENKINS-37184] [JENKINS-5124] Log the exception that is thrown if Jenksins can't get info() on a subversion repository using a tunnel

### DIFF
--- a/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition.java
+++ b/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition.java
@@ -179,6 +179,7 @@ public class ListSubversionTagsParameterDefinition extends ParameterDefinition {
       SVNURL repoURL = SVNURL.parseURIDecoded(getTagsDir());
 
       SVNRepository repo = SVNRepositoryFactory.create(repoURL);
+      repo.setTunnelProvider( SubversionSCM.createDefaultSVNOptions() );
       repo.setAuthenticationManager(authManager);
       SVNLogClient logClient = new SVNLogClient(authManager, null);
       
@@ -255,6 +256,7 @@ public class ListSubversionTagsParameterDefinition extends ParameterDefinition {
         return true;
       }
     } catch (SVNException e) {
+      LOGGER.log(Level.SEVERE, "An SVN exception occurred", e);
       return false;
     }
     return false;

--- a/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition.java
+++ b/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition.java
@@ -179,7 +179,7 @@ public class ListSubversionTagsParameterDefinition extends ParameterDefinition {
       SVNURL repoURL = SVNURL.parseURIDecoded(getTagsDir());
 
       SVNRepository repo = SVNRepositoryFactory.create(repoURL);
-      repo.setTunnelProvider( SubversionSCM.createDefaultSVNOptions() );
+      repo.setTunnelProvider(SubversionSCM.createDefaultSVNOptions());
       repo.setAuthenticationManager(authManager);
       SVNLogClient logClient = new SVNLogClient(authManager, null);
       


### PR DESCRIPTION
Log the exception that is thrown if Jenksins can't get info() on a subversion repository using a tunnel.  When the repository factory creates the repository, set the tunnel provider based on default svn options.
