### PR TITLE
Should be using Job instead of Item

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -3012,7 +3012,7 @@ public class SubversionSCM extends SCM implements Serializable {
                 return null;
             }
 
-            public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context, @QueryParameter String remote) {
+            public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Job<?,?> context, @QueryParameter String remote) {
                 if (context == null || !context.hasPermission(Item.EXTENDED_READ)) {
                     return new StandardListBoxModel();
                 }
@@ -3295,7 +3295,7 @@ public class SubversionSCM extends SCM implements Serializable {
                 return null;
             }
 
-            public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context,
+            public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Job<?,?> context,
                                                          @QueryParameter String realm) {
                 if (context == null || !context.hasPermission(Item.EXTENDED_READ)) {
                     return new StandardListBoxModel();

--- a/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition.java
+++ b/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition.java
@@ -371,7 +371,7 @@ public class ListSubversionTagsParameterDefinition extends ParameterDefinition {
         return FormValidation.warning("Unable to check tags directory.");
     }
 
-    public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context, @QueryParameter String tagsDir) {
+    public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Job<?,?> context, @QueryParameter String tagsDir) {
       if (context == null || !context.hasPermission(Item.BUILD)) {
         return new StandardListBoxModel();
       }


### PR DESCRIPTION
Setting the `doFillCredentialsIdItems` to use `Item` instead of `Job` causes credentials defined at the folder level to not properly be made available with certain types of projects.

Similar to the mercurial plugin :https://github.com/jenkinsci/mercurial-plugin/blob/41fda47ac7749cc55173cb91e0dc5d953ddf90df/src/main/java/hudson/plugins/mercurial/MercurialSCM.java#L1048.

@reviewbybees 