### PR TITLE
Upgrade to svnkit 1.8.14.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,12 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.tmatesoft.svnkit</groupId>
       <artifactId>svnkit</artifactId>
-      <version>1.8.11</version>
+      <version>1.8.14</version>
     </dependency>
     <dependency>
       <groupId>org.tmatesoft.svnkit</groupId>
       <artifactId>svnkit-cli</artifactId>
-      <version>1.8.11</version>
+      <version>1.8.14</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
SVNKit 1.8.14, released 10 Oct 2016, provides [a number of bug fixes](https://svn.svnkit.com/repos/svnkit/tags/1.8.14/CHANGES.txt).
It also addresses [SVNKIT-672](https://issues.tmatesoft.com/issue/SVNKIT-672), vastly improving performance on 32-bit Linux.