### PR TITLE
Fixing repository declarations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,10 +70,16 @@ THE SOFTWARE.
 
   <repositories>
     <repository>
-      <id>mavenTMateSoftReleasesRepository</id>
-      <url>http://maven.tmatesoft.com/content/repositories/releases/</url>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
Jenkins plugins should specify the Jenkins repository to make sure they can be built without a custom `~/.m2/settings.xml`, so part of #172 was wrong. (Inheriting `distributionManagement` is correct.)
#170 was not wrong, but the original use of a custom repository here was. Fixed by manually uploading the [third-party library in question](https://repo.jenkins-ci.org/releases/com/trilead/trilead-ssh2/1.0.0-build221/). That also allows other plugins to compile against `subversion` 2.7.1 without hassle.

@reviewbybees esp. @recena, @daniel-beck
