### PR TITLE
[JENKINS-36521] Print raw (not HTML escaped) commit messages

### DIFF
--- a/src/main/resources/hudson/scm/SubversionChangeLogSet/digest.jelly
+++ b/src/main/resources/hudson/scm/SubversionChangeLogSet/digest.jelly
@@ -60,7 +60,7 @@ THE SOFTWARE.
       <ol>
         <j:forEach var="cs" items="${it.logs}" varStatus="loop">
           <li>
-            ${cs.msgAnnotated}
+            <j:out value="${cs.msgAnnotated}"/>
             (<a href="${changesBaseUrl}changes#detail${loop.index}">${%detail}</a>
 
             <j:set var="cslink" value="${browser.getChangeSetLink(cs)}"/>

--- a/src/main/resources/hudson/scm/SubversionChangeLogSet/index.jelly
+++ b/src/main/resources/hudson/scm/SubversionChangeLogSet/index.jelly
@@ -44,7 +44,7 @@ THE SOFTWARE.
               <a href="${browser.getChangeSetLink(cs)}">${cs.revision}</a>
               by <a href="${rootURL}/${cs.author.url}/">${cs.author}</a>:
             </b><br/>
-            ${cs.msgAnnotated}
+            <j:out value="${cs.msgAnnotated}"/>
           </div>
         </td>
       </tr>


### PR DESCRIPTION
Commit decorators add clicable <a> links to issue IDs on build summary page,
but the security mechanism preventing XSS in .jelly,
escapes the HTML tags for .jelly files with:
jelly escape-by-default='true'

After the change, annotated commit messages are printed raw,
without HTML escaping.

Used method will be consistent with change in hudson/scm/SCM/project-changes.jelly
introduced in https://github.com/jenkinsci/jenkins/commit/41ab84fe0a1512fe52347d55fb58445174636896

Additional details:
https://wiki.jenkins-ci.org/display/JENKINS/Jelly+and+XSS+prevention
https://issues.jenkins-ci.org/browse/JENKINS-5135