### PR TITLE
add an svninfo step that can provide infos for a wc path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,9 @@ THE SOFTWARE.
 
   <properties>
     <jenkins.version>1.609.3</jenkins.version>
-    <java.level>6</java.level>
+    <java.level>7</java.level>
     <no-test-jar>false</no-test-jar>
-    <workflow.version>1.14.2</workflow.version>
+    <workflow.version>2.3</workflow.version>
     <findbugs.failOnError>false</findbugs.failOnError>
   </properties>
 
@@ -113,6 +113,11 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
       <version>1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -166,7 +171,6 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-aggregator</artifactId>
       <version>${workflow.version}</version>
-      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/jenkins/scm/impl/subversion/SvninfoStep.java
+++ b/src/main/java/jenkins/scm/impl/subversion/SvninfoStep.java
@@ -35,7 +35,6 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
-import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.tmatesoft.svn.core.SVNException;
 import org.tmatesoft.svn.core.wc.SVNClientManager;
@@ -44,9 +43,8 @@ import org.tmatesoft.svn.core.wc.SVNRevision;
 
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.FilePath.FileCallable;
 import hudson.remoting.VirtualChannel;
-import jenkins.security.Roles;
+import jenkins.MasterToSlaveFileCallable;
 
 /**
  * Provides data from svn info.
@@ -108,14 +106,9 @@ public final class SvninfoStep extends Step {
 
     }
 
-    private static final class SvnInfoFileCallable implements FileCallable<Map<String, String>> {
+    private static final class SvnInfoFileCallable extends MasterToSlaveFileCallable<Map<String, String>> {
 
         private static final long serialVersionUID = 1456116737119973646L;
-
-        @Override
-        public void checkRoles(final RoleChecker checker) throws SecurityException {
-            checker.check(this, Roles.SLAVE);
-        }
 
         @Override
         public Map<String, String> invoke(final File file, final VirtualChannel channel)

--- a/src/main/java/jenkins/scm/impl/subversion/SvninfoStep.java
+++ b/src/main/java/jenkins/scm/impl/subversion/SvninfoStep.java
@@ -1,0 +1,118 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Tobias Baum.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.scm.impl.subversion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.tmatesoft.svn.core.wc.SVNClientManager;
+import org.tmatesoft.svn.core.wc.SVNInfo;
+import org.tmatesoft.svn.core.wc.SVNRevision;
+
+import hudson.Extension;
+import hudson.FilePath;
+
+/**
+ * Provides data from svn info.
+ */
+public final class SvninfoStep extends Step {
+
+    private final String path;
+
+    @DataBoundConstructor
+    public SvninfoStep(final String path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return this.path;
+    }
+
+    @Override
+    public StepExecution start(final StepContext context) throws Exception {
+        return new Execution(this.path, context);
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public String getFunctionName() {
+            return "svninfo";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Provides some data from svn info as a map.";
+        }
+
+        @Override
+        public Set<Class<?>> getRequiredContext() {
+            return Collections.<Class<?>>singleton(FilePath.class);
+        }
+
+    }
+
+    public static final class Execution extends AbstractSynchronousNonBlockingStepExecution<Map<String, String>> {
+
+        private final String path;
+
+        Execution(final String path, final StepContext context) {
+            super(context);
+            this.path = path;
+        }
+
+        @Override
+        protected Map<String, String> run() throws Exception {
+            final SVNClientManager clientManager = SVNClientManager.newInstance();
+            try {
+                final File file = new File(this.getContext().get(FilePath.class).child(this.path).toURI());
+                final SVNInfo info = clientManager.getWCClient().doInfo(file, SVNRevision.WORKING);
+                final Map<String, String> result = new LinkedHashMap<String, String>();
+                result.put("REVISION", Long.toString(info.getRevision().getNumber()));
+                result.put("URL", info.getURL().toString());
+                result.put("CHECKSUM", info.getChecksum());
+                result.put("REPOSITORY_UUID", info.getRepositoryUUID());
+                result.put("LAST_AUTHOR", info.getAuthor());
+                result.put("LAST_CHANGE_REVISION", Long.toString(info.getCommittedRevision().getNumber()));
+                return Collections.unmodifiableMap(result);
+            } finally {
+                clientManager.dispose();
+            }
+        }
+
+        private static final long serialVersionUID = 1L;
+
+    }
+
+}

--- a/src/main/java/jenkins/scm/impl/subversion/SvninfoStep.java
+++ b/src/main/java/jenkins/scm/impl/subversion/SvninfoStep.java
@@ -30,11 +30,11 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.tmatesoft.svn.core.SVNException;
@@ -89,7 +89,7 @@ public final class SvninfoStep extends Step {
 
     }
 
-    public static final class Execution extends AbstractSynchronousNonBlockingStepExecution<Map<String, String>> {
+    static final class Execution extends SynchronousNonBlockingStepExecution<Map<String, String>> {
 
         private final String path;
 

--- a/src/main/resources/jenkins/scm/impl/subversion/SvninfoStep/config.jelly
+++ b/src/main/resources/jenkins/scm/impl/subversion/SvninfoStep/config.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2017 Tobias Baum.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+    <f:entry field="path" title="File or directory path">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/jenkins/scm/impl/subversion/SvninfoStep/help.html
+++ b/src/main/resources/jenkins/scm/impl/subversion/SvninfoStep/help.html
@@ -1,0 +1,6 @@
+<div>
+    <p>
+    SVN INFO step. It provides some SVN-specific information for the given path as a map (String to String).
+    Currently supported result keys are REVISION, URL, CHECKSUM, REPOSITORY_UUID, LAST_AUTHOR and LAST_CHANGE_REVISION.
+    </p>
+</div>

--- a/src/test/java/jenkins/scm/impl/subversion/SvninfoStepTest.java
+++ b/src/test/java/jenkins/scm/impl/subversion/SvninfoStepTest.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Tobias Baum.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.scm.impl.subversion;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class SvninfoStepTest {
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public SubversionSampleRepoRule sampleRepo = new SubversionSampleRepoRule();
+
+    @Test
+    public void testGetRevision() throws Exception {
+        this.sampleRepo.init();
+        final WorkflowJob p = this.r.jenkins.createProject(WorkflowJob.class, "demo");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n" +
+                "    ws {\n" +
+                "        dir('main') {\n" +
+                "            def result = svninfo(path: '" + this.sampleRepo.wc().replace("\\", "\\\\") + "')\n" +
+                "            echo 'TEST_REVISION=' + result.get('REVISION')\n" +
+                "        }\n" +
+                "    }\n" +
+                "}"));
+        final WorkflowRun b = this.r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        this.r.assertLogContains("TEST_REVISION=1", b);
+    }
+
+}


### PR DESCRIPTION
Hi,

I implemented an "svninfo" step that provides information like the current revision for a working copy path. If you want to, you can include it in the official release.

Background: We're currently porting our builds to pipeline and miss the SVN_REVISION environment variable. As a workaround, we first tried to shell out and use a native svn to get the info. That works, but the dependency on a native svn (possibly different from the one Jenkins uses) is a potential maintenance problem. I looked some time for another solution but then went ahead implementing it.

I added some more of the provided infos to the returned map. I selected ones I thought could be interesting, but the selection is nevertheless rather arbitrary. It should be easy to extend.

Best regards,
   Tobias