### PR TITLE
Update UpdateUpdater.java (Fail build when locked file instead of fresh check out. This is helpful when repositories are very large and takes hours for fresh check out.)

### DIFF
--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -183,7 +183,7 @@ public class UpdateUpdater extends WorkspaceUpdater {
                         
                         //show error instead of check out, useful for big repositories
                          listener.getLogger().println("Workspace appear to be locked, so Failing the build");
-+                        throw (InterruptedException) new InterruptedException().initCause(e);
+                         throw (InterruptedException) new InterruptedException().initCause(e);
                     }
                     if (errorCode == SVNErrorCode.WC_OBSTRUCTED_UPDATE) {
                         // HUDSON-1882. If existence of local files cause an update to fail,

--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -178,8 +178,12 @@ public class UpdateUpdater extends WorkspaceUpdater {
                     SVNErrorCode errorCode = cause.getErrorMessage().getErrorCode();
                     if (errorCode == SVNErrorCode.WC_LOCKED) {
                         // work space locked. try fresh check out
-                        listener.getLogger().println("Workspace appear to be locked, so getting a fresh workspace");
-                        return delegateTo(new CheckoutUpdater());
+                        //listener.getLogger().println("Workspace appear to be locked, so getting a fresh workspace");
+                        //return delegateTo(new CheckoutUpdater());
+                        
+                        //show error instead of check out, useful for big repositories
+                         listener.getLogger().println("Workspace appear to be locked, so Failing the build");
++                        throw (InterruptedException) new InterruptedException().initCause(e);
                     }
                     if (errorCode == SVNErrorCode.WC_OBSTRUCTED_UPDATE) {
                         // HUDSON-1882. If existence of local files cause an update to fail,


### PR DESCRIPTION
Fail build when locked file instead of fresh check out. This is helpful when repositories are very large and takes hours for fresh check out which flushes configurations as well.