### PR TITLE
[JENKINS-44076] : hudson.scm.SubversionChangeLogSet.LogEntry.getAffectedPaths() does not provide expected result for parametrized Repository URLs

### DIFF
--- a/src/main/java/hudson/scm/SubversionChangeLogSet.java
+++ b/src/main/java/hudson/scm/SubversionChangeLogSet.java
@@ -262,7 +262,16 @@ public final class SubversionChangeLogSet extends ChangeLogSet<LogEntry> {
                 }
             ModuleLocation[] locations = ((SubversionSCM)scm).getLocations();
             for (int i = 0; i < locations.length; i++) {
-                String commonPart = findCommonPart(locations[i].remote, path);
+                ModuleLocation expandedLocation = locations[i].getExpandedLocation(job);
+                // If the remote URL features a trailing '@REV' entry, strip it off before looking for common part
+                String expandedRemote = expandedLocation.remote;
+                if (expandedLocation.getRevision(null) != null) {
+                    int idx = expandedRemote.lastIndexOf('@');
+                    if (idx >= 0) {
+                        expandedRemote = expandedRemote.substring(0, idx);
+                    }
+                }
+                String commonPart = findCommonPart(expandedRemote, path);
                 if (commonPart != null) {
                     if (path.startsWith("/")) {
                         path = path.substring(1);


### PR DESCRIPTION
The issue is generally described in JIRA https://issues.jenkins-ci.org/browse/JENKINS-44076 along with the motivation and description of this proposed fix.

I have not been able to sensibly stub the execution context for the SubversionChangeLogSet.LogEntry.preparePath(String) method to create a relevant unit test for this change.