### PR TITLE
JENKINS-42186 Fix some potential file leaks

### DIFF
--- a/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition.java
+++ b/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition.java
@@ -171,6 +171,7 @@ public class ListSubversionTagsParameterDefinition extends ParameterDefinition {
   @Nonnull public List<String> getTags(@Nullable Job context) {
     List<String> dirs = new ArrayList<String>();
 
+    SVNRepository repo = null;
     try {
       ISVNAuthenticationProvider authProvider = CredentialsSVNAuthenticationProviderImpl.createAuthenticationProvider(
               context, getTagsDir(), getCredentialsId(), null
@@ -178,7 +179,7 @@ public class ListSubversionTagsParameterDefinition extends ParameterDefinition {
       ISVNAuthenticationManager authManager = SubversionSCM.createSvnAuthenticationManager(authProvider);
       SVNURL repoURL = SVNURL.parseURIDecoded(getTagsDir());
 
-      SVNRepository repo = SVNRepositoryFactory.create(repoURL);
+      repo = SVNRepositoryFactory.create(repoURL);
       repo.setAuthenticationManager(authManager);
       SVNLogClient logClient = new SVNLogClient(authManager, null);
       
@@ -194,6 +195,10 @@ public class ListSubversionTagsParameterDefinition extends ParameterDefinition {
       // logs are not translated (IMO, this is a bad idea to translate logs)
       LOGGER.log(Level.SEVERE, "An SVN exception occurred while listing the directory entries at " + getTagsDir(), e);
       return Collections.singletonList("!" + ResourceBundleHolder.get(ListSubversionTagsParameterDefinition.class).format("SVNException"));
+    } finally {
+       if (repo != null) {
+         repo.closeSession();
+       }
     }
 
     // SVNKit's doList() method returns also the parent dir, so we need to remove it

--- a/src/main/java/jenkins/scm/impl/subversion/SVNRepositoryView.java
+++ b/src/main/java/jenkins/scm/impl/subversion/SVNRepositoryView.java
@@ -66,29 +66,29 @@ public class SVNRepositoryView {
 
     public SVNRepositoryView(SVNURL repoURL, StandardCredentials credentials) throws SVNException, IOException {
         repository = SVNRepositoryFactory.create(repoURL);
-
-        File configDir = SVNWCUtil.getDefaultConfigurationDirectory();
-
-        ISVNAuthenticationManager sam = new SVNAuthenticationManager(configDir, null, null);
-
-        sam.setAuthenticationProvider(new CredentialsSVNAuthenticationProviderImpl(credentials));
-        SVNAuthStoreHandlerImpl.install(sam);
-        sam = new FilterSVNAuthenticationManager(sam) {
-            // If there's no time out, the blocking read operation may hang forever, because TCP itself
-            // has no timeout. So always use some time out. If the underlying implementation gives us some
-            // value (which may come from ~/.subversion), honor that, as long as it sets some timeout value.
-            @Override
-            public int getReadTimeout(SVNRepository repository) {
-                int r = super.getReadTimeout(repository);
-                if (r <= 0) {
-                    r = (int) TimeUnit2.MINUTES.toMillis(1);
-                }
-                return r;
-            }
-        };
-        repository.setTunnelProvider(SVNWCUtil.createDefaultOptions(true));
-        repository.setAuthenticationManager(sam);
         try {
+            File configDir = SVNWCUtil.getDefaultConfigurationDirectory();
+
+            ISVNAuthenticationManager sam = new SVNAuthenticationManager(configDir, null, null);
+
+            sam.setAuthenticationProvider(new CredentialsSVNAuthenticationProviderImpl(credentials));
+            SVNAuthStoreHandlerImpl.install(sam);
+            sam = new FilterSVNAuthenticationManager(sam) {
+                // If there's no time out, the blocking read operation may hang forever, because TCP itself
+                // has no timeout. So always use some time out. If the underlying implementation gives us some
+                // value (which may come from ~/.subversion), honor that, as long as it sets some timeout value.
+                @Override
+                public int getReadTimeout(SVNRepository repository) {
+                    int r = super.getReadTimeout(repository);
+                    if (r <= 0) {
+                        r = (int) TimeUnit2.MINUTES.toMillis(1);
+                    }
+                    return r;
+                }
+            };
+            repository.setTunnelProvider(SVNWCUtil.createDefaultOptions(true));
+            repository.setAuthenticationManager(sam);
+
             uuid = repository.getRepositoryUUID(true);
             if (uuid == null) { // TODO is this even possible? Javadoc is unclear.
                 throw new IOException("Could not find UUID for " + repoURL);

--- a/src/main/java/jenkins/scm/impl/subversion/SubversionSCMSource.java
+++ b/src/main/java/jenkins/scm/impl/subversion/SubversionSCMSource.java
@@ -286,10 +286,11 @@ public class SubversionSCMSource extends SCMSource {
      */
     @Override
     protected SCMRevision retrieve(String unparsedRevision, TaskListener listener) throws IOException, InterruptedException {
+        SVNRepositoryView repository = null;
         try {
             listener.getLogger().println("Opening connection to " + remoteBase);
             SVNURL repoURL = SVNURL.parseURIEncoded(remoteBase);
-            SVNRepositoryView repository = openSession(repoURL);
+            repository = openSession(repoURL);
             String repoPath = SubversionSCM.DescriptorImpl.getRelativePath(repoURL, repository.getRepository());
             String base;
             long revision;
@@ -310,6 +311,8 @@ public class SubversionSCMSource extends SCMSource {
             return new SCMRevisionImpl(new SCMHead(base), revision == -1 ? resolvedRevision : revision);
         } catch (SVNException e) {
             throw new IOException(e);
+        } finally {
+            closeSession(repository);
         }
     }
 

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -1223,8 +1223,12 @@ public class SubversionSCMTest extends AbstractSubversionTest {
 
     private void attemptAccess(ISVNAuthenticationManager m) throws SVNException {
         SVNRepository repository = SVNRepositoryFactory.create(repo);
-        repository.setAuthenticationManager(m);
-        repository.testConnection();
+        try {
+            repository.setAuthenticationManager(m);
+            repository.testConnection();
+        } finally {
+            repository.closeSession();
+        }
     }
 
     private ISVNAuthenticationManager createInMemoryManager() {


### PR DESCRIPTION
[JENKINS-42186](https://issues.jenkins-ci.org/browse/JENKINS-42186)

A quick scan of the source code shows that we don't properly clean up instances of `SVNRepository` like we should.

What seems to be happening is that we are creating `SVNRepositoryView` over and over in `retrieve` and not closing it. When this occurs, we end up with many instances of `SVNRepositoryView` open which has file descriptors open to a on disk cache (created by `DBMaker.newFileDB`). This is what eats all the file handles and causes havoc. 

PTAL @recena @jglick 

@reviewbybees