### PR TITLE
JENKINS-32302 dead code before Credentials API causes NPE

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -2266,17 +2266,7 @@ public class SubversionSCM extends SCM implements Serializable {
                 //    (so we store the password info here)
                 repository = SVNRepositoryFactory.create(SVNURL.parseURIDecoded(url));
                 repository.setTunnelProvider( createDefaultSVNOptions() );
-                AuthenticationManagerImpl authManager = upc.new AuthenticationManagerImpl(logWriter) {
-                    @Override
-                    protected void onSuccess(String realm, Credential cred) {
-                        LOGGER.info("Persisted "+cred+" for "+realm);
-                        credentials.put(realm, cred);
-                        save();
-                        if (upc.inContextOf!=null)
-                            new PerJobCredentialStore(upc.inContextOf).acknowledgeAuthentication(realm,cred);
-
-                    }
-                };
+                AuthenticationManagerImpl authManager = upc.new AuthenticationManagerImpl(logWriter);
                 authManager.setAuthenticationForced(true);
                 repository.setAuthenticationManager(authManager);
                 repository.testConnection();


### PR DESCRIPTION
It looks like there was some sort of credentials management within this plugin before the credentials api was introduced. Some of that code is still on hot paths and caused the NPE reported in [JENKINS-32302](https://issues.jenkins-ci.org/browse/JENKINS-32302). @stephenc this is an oldie of yours I think. I wonder if its safe just to remove all that migration code and the old credentials impl?

@reviewbybees 
