### PR TITLE
Change the Additional Credentials help to give correct realm name for svn+ssh repositories

### DIFF
--- a/src/main/resources/hudson/scm/SubversionSCM/AdditionalCredentials/help-realm.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/AdditionalCredentials/help-realm.html
@@ -1,4 +1,5 @@
 <div>
     This is the realm that the SvnKit library associates with a specific checkout. For most Subversion servers this
-    will typically be of the format <code>&lt;<i>scheme</i><code>://</code><i>hostname(:port)</i>/<i>path...</i>&gt;</code>
+    will typically be of the format <code>&lt;<i>scheme</i>://<i>hostname</i>(:<i>port</i>)&gt; <i>name</i></code>,
+    while for servers accessed via <code>svn+ssh</code> it is of the format <code>(<i>username</i>@)svn+ssh://<i>hostname</i>(:<i>port</i>)</code>.
 </div>

--- a/src/main/resources/hudson/scm/SubversionSCM/help-additionalCredentials.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-additionalCredentials.html
@@ -15,9 +15,11 @@
         <li>Use the command line <code>svn</code> program.
             <ul>
                 <li>If you don't have stored the credentials, run e.g. <code>svn info https://svnserver/repo</code> and it will tell you the realm when asking you to enter a password, e.g.: <em>Authentication realm: &lt;svn://svnserver:3690&gt; VisualSVN Server</em>.</li>
-                <li>If you have already stored the credentials to access the repository, look for the realm name in one of the files in <code>~/.subversion/auth/svn/simple</code>; it will be two lines below the line <code>svn:realmstring</code></li>
+                <li>If you have already stored the credentials to access the repository, look for the realm name in one of the files in <code>~/.subversion/auth/svn/simple</code>; it will be two lines below the line <code>svn:realmstring</code>.</li>
             </ul>
         </li>
+        <li>When accessing a repository via the <code>svn+ssh</code> protocol, the realm has the format <code>username@svn+ssh://host:port</code> &ndash; note that the username is <em>before</em> the <code>svn+ssh://</code>
+        (unlike the URL used for normal SVN operations), and that there are no angle brackets and no realm name. For this protocol the default port is 22.</li>
     </ul>
-    <p>Make sure to enter the realm <em>exactly</em> as shown, starting with a <code>&lt;</code>.
-</div>
+    <p>Make sure to enter the realm <em>exactly</em> as shown, starting with a <code>&lt;</code> (except for repositories accessed via <code>svn+ssh</code> &ndash; see above).
+ </div>


### PR DESCRIPTION
In its current form, the Jenkins Subversion plugin does not indicate the correct realm name to use for repositories accessed using the **svn+ssh://** protocol. This commit is intended to fix this, as I spent 3 days trying to work out how to run a Jenkins job where one repository had an svn:external pointing to an **svn+ssh://** repository, and I don't want anyone else to have the same problem!