### PR TITLE
Repository session was not closed for unexpected exceptions

### DIFF
--- a/src/main/java/jenkins/scm/impl/subversion/SVNRepositoryView.java
+++ b/src/main/java/jenkins/scm/impl/subversion/SVNRepositoryView.java
@@ -66,6 +66,7 @@ public class SVNRepositoryView {
 
     public SVNRepositoryView(SVNURL repoURL, StandardCredentials credentials) throws SVNException, IOException {
         repository = SVNRepositoryFactory.create(repoURL);
+        success = false;
         try {
             File configDir = SVNWCUtil.getDefaultConfigurationDirectory();
 
@@ -122,12 +123,11 @@ public class SVNRepositoryView {
             this.cache = cache;
             this.data = this.cache.getHashMap(credentials == null ? "data" : "data-" + credentials.getId());
             cache.commit();
-        } catch (SVNException e) {
-            repository.closeSession();
-            throw e;
-        } catch (IOException e) {
-            repository.closeSession();
-            throw e;
+            success = true;
+        } finally {
+            if (!success) {
+                repository.closeSession();
+            }
         }
     }
 

--- a/src/main/java/jenkins/scm/impl/subversion/SVNRepositoryView.java
+++ b/src/main/java/jenkins/scm/impl/subversion/SVNRepositoryView.java
@@ -66,7 +66,7 @@ public class SVNRepositoryView {
 
     public SVNRepositoryView(SVNURL repoURL, StandardCredentials credentials) throws SVNException, IOException {
         repository = SVNRepositoryFactory.create(repoURL);
-        success = false;
+        boolean success = false;
         try {
             File configDir = SVNWCUtil.getDefaultConfigurationDirectory();
 


### PR DESCRIPTION
Previous code caught two specific checked exceptions and closed the repository session only for those. But RuntimeException could occur as well, so the new pattern will work in all cases where success did not occur.