### PR TITLE
[JENKINS-45362] Workaround for not detecting changes in externals

### DIFF
--- a/src/main/resources/jenkins/scm/impl/subversion/SubversionSCMSource/config-detail.jelly
+++ b/src/main/resources/jenkins/scm/impl/subversion/SubversionSCMSource/config-detail.jelly
@@ -36,4 +36,7 @@
   <f:entry title="${%Exclude branches}" field="excludes">
     <f:textbox default="${descriptor.DEFAULT_EXCLUDES}"/>
   </f:entry>
+  <f:entry title="${%Force scanning for updates in externals}" field="forceScanExternals">
+    <f:checkbox/>
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
Like discussed in PR #189 the clean solution would be to extend SCMRevisionImpl to encode the revisions of all externals. But setting isDeterministic() to false is a simple workaround that solves the issue.