### PR TITLE
Fix memory leak (JENKINS-15376)

### DIFF
--- a/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition.java
+++ b/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition.java
@@ -69,6 +69,7 @@ import org.tmatesoft.svn.core.auth.ISVNAuthenticationManager;
 import org.tmatesoft.svn.core.auth.ISVNAuthenticationProvider;
 import org.tmatesoft.svn.core.io.SVNRepository;
 import org.tmatesoft.svn.core.io.SVNRepositoryFactory;
+import org.tmatesoft.svn.core.wc.SVNClientManager;
 import org.tmatesoft.svn.core.wc.SVNLogClient;
 import org.tmatesoft.svn.core.wc.SVNRevision;
 
@@ -176,6 +177,7 @@ public class ListSubversionTagsParameterDefinition extends ParameterDefinition {
     List<String> dirs = new ArrayList<String>();
 
     SVNRepository repo = null;
+    SVNClientManager clientManager = null;
     try {
       ISVNAuthenticationProvider authProvider = CredentialsSVNAuthenticationProviderImpl.createAuthenticationProvider(
               context, getTagsDir(), getCredentialsId(), null, TaskListener.NULL
@@ -185,7 +187,8 @@ public class ListSubversionTagsParameterDefinition extends ParameterDefinition {
 
       repo = SVNRepositoryFactory.create(repoURL);
       repo.setAuthenticationManager(authManager);
-      SVNLogClient logClient = new SVNLogClient(authManager, null);
+      clientManager = SVNClientManager.newInstance(null,authManager);
+      SVNLogClient logClient = clientManager.getLogClient();
       
       if (isSVNRepositoryProjectRoot(repo)) {
         dirs = this.getSVNRootRepoDirectories(logClient, repoURL);
@@ -202,6 +205,9 @@ public class ListSubversionTagsParameterDefinition extends ParameterDefinition {
     } finally {
        if (repo != null) {
          repo.closeSession();
+       }
+       if (clientManager != null) {
+         clientManager.dispose();
        }
     }
 


### PR DESCRIPTION
@jglick, @oleg-nenashev
This PR fixes the memory leak reported in JENKINS-15376. It is based on #162 but with the merge conflict resolved. (I.e. it is similar to #166). When this PR gets merged both can be closed.

All credits go to @2improveIT and @hplatou who already came up with a fix for this.

Without this fix our Jenkins runs out of memory every 2 or 3 days. It would be nice to see this merged so other people can benefit from it as well.