### PR TITLE
[JENKINS-14541] --quiet mode for svn checkout / update

### DIFF
--- a/src/main/java/hudson/scm/SubversionEventHandlerImpl.java
+++ b/src/main/java/hudson/scm/SubversionEventHandlerImpl.java
@@ -36,9 +36,12 @@ public class SubversionEventHandlerImpl extends SVNEventAdapter {
 
     protected final File baseDir;
 
-    public SubversionEventHandlerImpl(PrintStream out, File baseDir) {
+    protected final boolean quietOperation;
+
+    public SubversionEventHandlerImpl(PrintStream out, File baseDir, boolean quietOperation) {
         this.out = out;
         this.baseDir = baseDir;
+        this.quietOperation = quietOperation;
     }
 
     public void handleEvent(SVNEvent event, double progress) throws SVNException {
@@ -54,6 +57,10 @@ public class SubversionEventHandlerImpl extends SVNEventAdapter {
         }
 
         SVNEventAction action = event.getAction();
+        if (quietOperation && (action != SVNEventAction.UPDATE_COMPLETED)) {
+            //  Skips logging
+            return;
+        }
 
         {// commit notifications
             if (action == SVNEventAction.COMMIT_ADDED) {

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -245,6 +245,7 @@ public class SubversionSCM extends SCM implements Serializable {
 
     private boolean ignoreDirPropChanges;
     private boolean filterChangelog;
+    private boolean quietOperation;
 
     /**
      * A cache of the svn:externals (keyed by project).
@@ -338,12 +339,24 @@ public class SubversionSCM extends SCM implements Serializable {
         this(locations, workspaceUpdater, browser, excludedRegions, excludedUsers, excludedRevprop, excludedCommitMessages, includedRegions, ignoreDirPropChanges, false, null);
     }
 
+    /**
+     *  @deprecated by quietOperation
+     */
+    public SubversionSCM(List<ModuleLocation> locations, WorkspaceUpdater workspaceUpdater,
+            SubversionRepositoryBrowser browser, String excludedRegions, String excludedUsers,
+            String excludedRevprop, String excludedCommitMessages,
+            String includedRegions, boolean ignoreDirPropChanges, boolean filterChangelog,
+            List<AdditionalCredentials> additionalCredentials) {
+        this(locations, workspaceUpdater, browser, excludedRegions, excludedUsers, excludedRevprop, excludedCommitMessages, 
+            includedRegions, ignoreDirPropChanges, false, null, false);
+    }
+
     @DataBoundConstructor
     public SubversionSCM(List<ModuleLocation> locations, WorkspaceUpdater workspaceUpdater,
                          SubversionRepositoryBrowser browser, String excludedRegions, String excludedUsers,
                          String excludedRevprop, String excludedCommitMessages,
                          String includedRegions, boolean ignoreDirPropChanges, boolean filterChangelog,
-                         List<AdditionalCredentials> additionalCredentials) {
+                         List<AdditionalCredentials> additionalCredentials, boolean quietOperation) {
         for (Iterator<ModuleLocation> itr = locations.iterator(); itr.hasNext(); ) {
             ModuleLocation ml = itr.next();
             String remote = Util.fixEmptyAndTrim(ml.remote);
@@ -367,6 +380,7 @@ public class SubversionSCM extends SCM implements Serializable {
         this.includedRegions = includedRegions;
         this.ignoreDirPropChanges = ignoreDirPropChanges;
         this.filterChangelog = filterChangelog;
+        this.quietOperation = quietOperation;
     }
 
     /**
@@ -666,6 +680,18 @@ public class SubversionSCM extends SCM implements Serializable {
       return filterChangelog;
     }
 
+    @Exported
+    public boolean isQuietOperation() {
+      return quietOperation;
+    }
+
+    /**
+     * Convenience method solely for testing.
+     */
+    public void setQuietOperation(boolean quietOperation) {
+        this.quietOperation = quietOperation;
+    }
+
     // TODO: 2.60+ Delete this override.
     @Override
     public void buildEnvVars(AbstractBuild<?,?> build, Map<String,String> env) {
@@ -898,7 +924,7 @@ public class SubversionSCM extends SCM implements Serializable {
         Set<String> unauthenticatedRealms = new LinkedHashSet<String>();
         for (ModuleLocation location : getLocations(env, build)) {
             CheckOutTask checkOutTask =
-                    new CheckOutTask(build, this, location, build.getTimestamp().getTime(), listener, env);
+                    new CheckOutTask(build, this, location, build.getTimestamp().getTime(), listener, env, quietOperation);
             externals.addAll(workspace.act(checkOutTask));
             unauthenticatedRealms.addAll(checkOutTask.getUnauthenticatedRealms());
             // olamy: remove null check at it cause test failure
@@ -953,13 +979,15 @@ public class SubversionSCM extends SCM implements Serializable {
     private static class CheckOutTask extends UpdateTask implements FileCallable<List<External>> {
         private final UpdateTask task;
 
-         public CheckOutTask(Run<?, ?> build, SubversionSCM parent, ModuleLocation location, Date timestamp, TaskListener listener, EnvVars env) {
+        public CheckOutTask(Run<?, ?> build, SubversionSCM parent, ModuleLocation location, Date timestamp,
+                            TaskListener listener, EnvVars env, boolean quietOperation) {
             this.authProvider = parent.createAuthenticationProvider(build.getParent(), location, listener);
             this.timestamp = timestamp;
             this.listener = listener;
             this.location = location;
             this.revisions = build.getAction(RevisionParameterAction.class);
             this.task = parent.getWorkspaceUpdater().createTask();
+            this.quietOperation = quietOperation;
         }
 
         public Set<String> getUnauthenticatedRealms() {

--- a/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
+++ b/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
@@ -91,10 +91,11 @@ public class CheckoutUpdater extends WorkspaceUpdater {
                     String revisionName = r.getDate() != null ? fmt.format(r.getDate()) : r.toString();
 
                     listener.getLogger().println("Checking out " + location.getSVNURL().toString() + " at revision " +
-                            revisionName);
+                            revisionName + (quietOperation ? " --quiet" : ""));
 
                     File local = new File(ws, location.getLocalDir());
-                    SubversionUpdateEventHandler eventHandler = new SubversionUpdateEventHandler(new PrintStream(pos), externals, local, location.getLocalDir());
+                    SubversionUpdateEventHandler eventHandler = new SubversionUpdateEventHandler(
+                        new PrintStream(pos), externals, local, location.getLocalDir(), quietOperation);
                     svnuc.setEventHandler(eventHandler);
                     svnuc.setExternalsHandler(eventHandler);
                     svnuc.setIgnoreExternals(location.isIgnoreExternalsOption());

--- a/src/main/java/hudson/scm/subversion/SubversionUpdateEventHandler.java
+++ b/src/main/java/hudson/scm/subversion/SubversionUpdateEventHandler.java
@@ -63,8 +63,9 @@ final class SubversionUpdateEventHandler extends SubversionEventHandlerImpl impl
      */
     private final String modulePath;
     
-    public SubversionUpdateEventHandler(PrintStream out, List<External> externals, File moduleDir, String modulePath) {
-        super(out,moduleDir);
+    public SubversionUpdateEventHandler(PrintStream out, List<External> externals, File moduleDir,
+                                        String modulePath, boolean quietOperation) {
+        super(out, moduleDir, quietOperation);
         this.externals = externals;
         this.modulePath = modulePath;
     }

--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -139,7 +139,8 @@ public class UpdateUpdater extends WorkspaceUpdater {
 
             try {
                 File local = new File(ws, location.getLocalDir());
-                SubversionUpdateEventHandler eventHandler = new SubversionUpdateEventHandler(listener.getLogger(), externals, local, location.getLocalDir());
+                SubversionUpdateEventHandler eventHandler = new SubversionUpdateEventHandler(
+                    listener.getLogger(), externals, local, location.getLocalDir(), quietOperation);
                 svnuc.setEventHandler(eventHandler);
                 svnuc.setExternalsHandler(eventHandler);
 
@@ -154,11 +155,13 @@ public class UpdateUpdater extends WorkspaceUpdater {
                 
                 switch (svnCommand) {
                     case UPDATE:
-                        listener.getLogger().println("Updating " + location.remote + " at revision " + revisionName);
+                        listener.getLogger().println("Updating " + location.remote + " at revision "
+                            + revisionName + (quietOperation ? " --quiet" : ""));
                         svnuc.doUpdate(local.getCanonicalFile(), r, svnDepth, true, true);
                         break;
                     case SWITCH:
-                        listener.getLogger().println("Switching to " + location.remote + " at revision " + revisionName);
+                        listener.getLogger().println("Switching to " + location.remote + " at revision "
+                            + revisionName + (quietOperation ? " --quiet" : ""));
                         svnuc.doSwitch(local.getCanonicalFile(), location.getSVNURL(), r, r, svnDepth, true, true, true);
                         break;
                     case CHECKOUT:

--- a/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
+++ b/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
@@ -134,6 +134,11 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
         public File ws;
 
         /**
+         * --quiet for subversion operations. Default = false.
+         */
+        public boolean quietOperation;
+
+        /**
          * If the build parameter is specified with specific version numbers, this field captures that. Can be null.
          */
         public RevisionParameterAction revisions;
@@ -158,6 +163,7 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
             t.location = this.location;
             t.revisions = this.revisions;
             t.ws = this.ws;
+            t.quietOperation = this.quietOperation;
 
             return t.perform();
         }

--- a/src/main/resources/hudson/scm/SubversionSCM/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/config.jelly
@@ -30,9 +30,13 @@ THE SOFTWARE.
   
   <f:entry title="${%Additional Credentials}" help="/descriptor/hudson.scm.SubversionSCM/help/additionalCredentials">
     <f:repeatableProperty field="additionalCredentials" add="${%Add additional credentials...}"/>
- </f:entry>
+  </f:entry>
 
   <f:dropdownDescriptorSelector title="${%Check-out Strategy}" field="workspaceUpdater" descriptors="${descriptor.getWorkspaceUpdaterDescriptors()}"/>
+
+  <f:entry title="${%Quiet check-out}" field="quietOperation">
+    <f:checkbox default="true"/>
+  </f:entry>
 
   <t:listScmBrowsers name="svn.browser" />
   <f:advanced>

--- a/src/main/resources/hudson/scm/SubversionSCM/help-quietOperation.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-quietOperation.html
@@ -1,4 +1,3 @@
 <div>
-    Mimics subversion command line "--quiet" parameter for <b>check-out / update</b> operations to help keep the output shorter.<br>
-    <i>Prints nothing, or only summary information.</i>
+    <p>Mimics subversion command line <code>--quiet</code> parameter for <strong>check out / update</strong> operations to help keep the output shorter. Prints nothing, or only summary information.</p>
 </div>

--- a/src/main/resources/hudson/scm/SubversionSCM/help-quietOperation.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-quietOperation.html
@@ -1,0 +1,4 @@
+<div>
+    Mimics subversion command line "--quiet" parameter for <b>check-out / update</b> operations to help keep the output shorter.<br>
+    <i>Prints nothing, or only summary information.</i>
+</div>

--- a/src/main/resources/hudson/scm/SubversionSCM/help-quietOperation_zh_TW.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-quietOperation_zh_TW.html
@@ -1,0 +1,3 @@
+<div>
+    模仿 Subversion 客户端命令 "--quiet" 選項於 <b>check-out / update</b> 子命所顯示的訊息。<br> "請求客戶端在執行操作時只顯示重要信息"
+</div>

--- a/src/main/resources/hudson/scm/SubversionSCM/help-quietOperation_zh_TW.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-quietOperation_zh_TW.html
@@ -1,3 +1,3 @@
 <div>
-    模仿 Subversion 客户端命令 "--quiet" 選項於 <b>check-out / update</b> 子命所顯示的訊息。<br> "請求客戶端在執行操作時只顯示重要信息"
+    <p>模仿 Subversion 客户端命令 <code>--quiet</code> 選項於 <strong>Check Out / Update</strong> 子命所顯示的訊息。請求客戶端在執行操作時只顯示重要信息。</p>
 </div>

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -820,6 +820,33 @@ public class SubversionSCMTest extends AbstractSubversionTest {
     }
 
     /**
+     * Makes sure that quiet operation shows lesser output.
+     */
+    @Issue("JENKINS-14541")
+    @Test
+    public void testQuietCheckout() throws Exception {
+        SubversionSCM local = loadSvnRepo();
+        local.setWorkspaceUpdater(new CheckoutUpdater());
+        FreeStyleProject p = r.createFreeStyleProject("quietOperation");
+        p.setScm(local);
+
+        local.setQuietOperation(true);
+        FreeStyleBuild bQuiet = r.assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause()).get());
+        List<String> logsQuiet = bQuiet.getLog(LOG_LIMIT);
+        //  This line in log should end with --quiet
+        assertTrue(logsQuiet.get(4).endsWith("--quiet"));
+        assertTrue(logsQuiet.get(5).equals("At revision 1"));
+
+        local.setQuietOperation(false);
+        FreeStyleBuild bVerbose = r.assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause()).get());
+        List<String> logsVerbose = bVerbose.getLog(LOG_LIMIT);
+        //  This line in log should NOT end with --quiet
+        assertFalse(logsVerbose.get(4).endsWith("--quiet"));
+        assertTrue(logsVerbose.get(5).endsWith("readme.txt"));
+        assertTrue(logsVerbose.get(6).equals("At revision 1"));
+    }
+    
+    /**
      * Makes sure the symbolic link is checked out correctly. There seems to be
      */
     @Issue("JENKINS-3904")


### PR DESCRIPTION
Adds an option in Subversion scm config to reduce significant amount of logs produced during build when checking out / updating working copy.

Includes both English and traditional Chinese help files / descriptions.
Also added a unit test for this feature.

https://issues.jenkins-ci.org/browse/JENKINS-14541

CC @recena, @jglick, @oleg-nenashev, @TomaszHal 

See https://github.com/jenkinsci/subversion-plugin/pull/136