### PR TITLE
Make as-it-is checkout only files initally

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -2944,6 +2944,22 @@ public class SubversionSCM extends SCM implements Serializable {
         }
 
         /**
+         * Returns the SVNDepth to use for reverting the module if svn up with revert before is selected
+         *
+         * This is normally the requested SVN depth except when the user
+         * has requested as-it-is and then we use infinity to actually revert everything
+         *
+         * @return {@link org.tmatesoft.svn.core.SVNDepth} value.
+         */
+        public SVNDepth getSvnDepthForRevert() {
+            if(getDepthOption().equals("unknown")) {
+                return SVNDepth.INFINITY;
+            } else {
+                return getSvnDepth(getDepthOption());
+            }
+        }
+
+        /**
          * Determines if subversion externals definitions should be ignored.
          *
          * @return true if subversion externals definitions should be ignored.

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -2907,6 +2907,43 @@ public class SubversionSCM extends SCM implements Serializable {
         }
 
         /**
+         * Returns {@link org.tmatesoft.svn.core.SVNDepth} by string value.
+         *
+         * @return {@link org.tmatesoft.svn.core.SVNDepth} value.
+         */
+        private static SVNDepth getSvnDepth(String name) {
+            return SVNDepth.fromString(name);
+        }
+
+        /**
+         * Returns the SVNDepth to use for updating the module.
+         *
+         * This is just mapping the depthOption to an SVN Depth
+         *
+         * @return {@link org.tmatesoft.svn.core.SVNDepth} value.
+         */
+        public SVNDepth getSvnDepthForUpdate() {
+            return getSvnDepth(getDepthOption());
+        }
+
+        /**
+         * Returns the SVNDepth to use for checking out the module.
+         *
+         * This is normally the requested SVN depth except when the user
+         * has requested as-it-is and then we use files so that we don't check
+         * everything out.
+         *
+         * @return {@link org.tmatesoft.svn.core.SVNDepth} value.
+         */
+        public SVNDepth getSvnDepthForCheckout() {
+            if(getDepthOption().equals("unknown")) {
+                return SVNDepth.FILES;
+            } else {
+                return getSvnDepth(getDepthOption());
+            }
+        }
+
+        /**
          * Determines if subversion externals definitions should be ignored.
          *
          * @return true if subversion externals definitions should be ignored.

--- a/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
+++ b/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
@@ -98,7 +98,7 @@ public class CheckoutUpdater extends WorkspaceUpdater {
                     svnuc.setEventHandler(eventHandler);
                     svnuc.setExternalsHandler(eventHandler);
                     svnuc.setIgnoreExternals(location.isIgnoreExternalsOption());
-                    SVNDepth svnDepth = getSvnDepth(location.getDepthOption());
+                    SVNDepth svnDepth = location.getSvnDepthForCheckout();
                     SvnCheckout checkout = svnuc.getOperationsFactory().createCheckout();
                     checkout.setSource(SvnTarget.fromURL(location.getSVNURL(), SVNRevision.HEAD));
                     checkout.setSingleTarget(SvnTarget.fromFile(local.getCanonicalFile()));

--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -150,7 +150,7 @@ public class UpdateUpdater extends WorkspaceUpdater {
                 
                 svnuc.setIgnoreExternals(location.isIgnoreExternalsOption());
                 preUpdate(location, local);
-                SVNDepth svnDepth = getSvnDepth(location.getDepthOption());
+                SVNDepth svnDepth = location.getSvnDepthForUpdate();
                 
                 switch (svnCommand) {
                     case UPDATE:

--- a/src/main/java/hudson/scm/subversion/UpdateWithRevertUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateWithRevertUpdater.java
@@ -60,7 +60,7 @@ public class UpdateWithRevertUpdater extends WorkspaceUpdater {
             listener.getLogger().println("Reverting " + local + " to depth " + module.getDepthOption() + " with ignoreExternals: " + module.isIgnoreExternalsOption());
             final SVNWCClient svnwc = manager.getWCClient();
             svnwc.setIgnoreExternals(module.isIgnoreExternalsOption());
-            svnwc.doRevert(new File[]{local.getCanonicalFile()}, getSvnDepth(module.getDepthOption()), null);
+            svnwc.doRevert(new File[]{local.getCanonicalFile()}, module.getSvnDepthForUpdate(), null);
         }
     }
 

--- a/src/main/java/hudson/scm/subversion/UpdateWithRevertUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateWithRevertUpdater.java
@@ -60,7 +60,7 @@ public class UpdateWithRevertUpdater extends WorkspaceUpdater {
             listener.getLogger().println("Reverting " + local + " to depth " + module.getDepthOption() + " with ignoreExternals: " + module.isIgnoreExternalsOption());
             final SVNWCClient svnwc = manager.getWCClient();
             svnwc.setIgnoreExternals(module.isIgnoreExternalsOption());
-            svnwc.doRevert(new File[]{local.getCanonicalFile()}, module.getSvnDepthForUpdate(), null);
+            svnwc.doRevert(new File[]{local.getCanonicalFile()}, module.getSvnDepthForRevert(), null);
         }
     }
 

--- a/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
+++ b/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
@@ -200,6 +200,7 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
          *      module location depth options or SVNDepth.fromString directly if you've taken the
          *      depth from another source.
          */
+        @Deprecated
         protected static SVNDepth getSvnDepth(String name) {
             return SVNDepth.fromString(name);
         }

--- a/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
+++ b/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
@@ -190,15 +190,6 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
             return r;
         }
 
-        /**
-         * Returns {@link org.tmatesoft.svn.core.SVNDepth} by string value.
-         *
-         * @return {@link org.tmatesoft.svn.core.SVNDepth} value.
-         */
-        protected static SVNDepth getSvnDepth(String name) {
-            return SVNDepth.fromString(name);
-        }
-
         private static final long serialVersionUID = 1L;
     }
 }

--- a/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
+++ b/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
@@ -190,6 +190,20 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
             return r;
         }
 
+        /**
+         * Returns {@link org.tmatesoft.svn.core.SVNDepth} by string value.
+         *
+         * @return {@link org.tmatesoft.svn.core.SVNDepth} value.
+         *
+         * @deprecated as of 2.10
+         *      Use SubversionSCM.ModuleLocation.getSVNDepthFor* functions to correctly interpret
+         *      module location depth options or SVNDepth.fromString directly if you've taken the
+         *      depth from another source.
+         */
+        protected static SVNDepth getSvnDepth(String name) {
+            return SVNDepth.fromString(name);
+        }
+
         private static final long serialVersionUID = 1L;
     }
 }


### PR DESCRIPTION
SVNKit checks out to infinity by default if unknown is given as the
depth to checkout. If you're using as-it-is you probably don't want the
whole source tree, so change as-it-is to set the depth to files for
checkout and unknown for updates.

Not sure how flexible to be here some people might really want immediates or empty instead of files. But files is probably close enough isn't it. There could be an extra setting for this but I don't think that necessary.