### PR TITLE
Add new option "cancelProcessOnExternalsFail" for ModuleLocation

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -2709,11 +2709,11 @@ public class SubversionSCM extends SCM implements Serializable {
         @Exported
         public boolean ignoreExternalsOption;
 
-      /**
-       * Flag to cancel the process when checkout/update svn:externals failed.
-       */
-      @Exported
-      public boolean cancelProcessOnExternalsFail;
+        /**
+         * Flag to cancel the process when checkout/update svn:externals failed.
+         */
+        @Exported
+        public boolean cancelProcessOnExternalsFail;
 
         /**
          * Cache of the repository UUID.
@@ -2744,13 +2744,13 @@ public class SubversionSCM extends SCM implements Serializable {
             this(remote,null,local,depthOption,ignoreExternalsOption, false);
         }
 
-      /**
-       * Constructor to support backwards compatibility.
-       */
-      @Deprecated
-      public ModuleLocation(String remote, String credentialsId, String local, String depthOption, boolean ignoreExternalsOption) {
-        this(remote,credentialsId,local,depthOption,ignoreExternalsOption, false);
-      }
+        /**
+         * Constructor to support backwards compatibility.
+         */
+        @Deprecated
+        public ModuleLocation(String remote, String credentialsId, String local, String depthOption, boolean ignoreExternalsOption) {
+          this(remote,credentialsId,local,depthOption,ignoreExternalsOption, false);
+        }
 
         @DataBoundConstructor
         public ModuleLocation(String remote, String credentialsId, String local, String depthOption, boolean ignoreExternalsOption,
@@ -2760,7 +2760,7 @@ public class SubversionSCM extends SCM implements Serializable {
             this.local = fixEmptyAndTrim(local);
             this.depthOption = StringUtils.isEmpty(depthOption) ? SVNDepth.INFINITY.getName() : depthOption;
             this.ignoreExternalsOption = ignoreExternalsOption;
-          this.cancelProcessOnExternalsFail = cancelProcessOnExternalsFail;
+            this.cancelProcessOnExternalsFail = cancelProcessOnExternalsFail;
         }
 
         public ModuleLocation withRemote(String remote) {
@@ -2783,9 +2783,9 @@ public class SubversionSCM extends SCM implements Serializable {
             return new ModuleLocation(remote, credentialsId, local, depthOption, ignoreExternalsOption, cancelProcessOnExternalsFail);
         }
 
-      public ModuleLocation withCancelProcessOnExternalsFailed(boolean cancelProcessOnExternalsFailed) {
-        return new ModuleLocation(remote, credentialsId, local, depthOption, ignoreExternalsOption, cancelProcessOnExternalsFailed);
-      }
+        public ModuleLocation withCancelProcessOnExternalsFailed(boolean cancelProcessOnExternalsFailed) {
+          return new ModuleLocation(remote, credentialsId, local, depthOption, ignoreExternalsOption, cancelProcessOnExternalsFailed);
+        }
 
         /**
          * Local directory to place the file to.
@@ -2957,14 +2957,14 @@ public class SubversionSCM extends SCM implements Serializable {
             return ignoreExternalsOption;
         }
 
-      /**
-       * Determines if the process should be cancelled when checkout/update svn:externals failed.
-       *
-       * @return true if the process should be cancelled when checkout/update svn:externals failed.
-       */
-      public boolean isCancelProcessOnExternalsFail() {
-        return cancelProcessOnExternalsFail;
-      }
+        /**
+         * Determines if the process should be cancelled when checkout/update svn:externals failed.
+         *
+         * @return true if the process should be cancelled when checkout/update svn:externals failed.
+         */
+        public boolean isCancelProcessOnExternalsFail() {
+          return cancelProcessOnExternalsFail;
+        }
 
         /**
          * Expand location value based on Build parametric execution.
@@ -3002,10 +3002,10 @@ public class SubversionSCM extends SCM implements Serializable {
             return parse(remoteLocations, null, localLocations, depthOptions, isIgnoreExternals, null);
         }
 
-      @Deprecated
-      public static List<ModuleLocation> parse(String[] remoteLocations, String[] credentialIds, String[] localLocations, String[] depthOptions, boolean[] isIgnoreExternals) {
-        return parse(remoteLocations, credentialIds, localLocations, depthOptions, isIgnoreExternals, null);
-      }
+        @Deprecated
+        public static List<ModuleLocation> parse(String[] remoteLocations, String[] credentialIds, String[] localLocations, String[] depthOptions, boolean[] isIgnoreExternals) {
+          return parse(remoteLocations, credentialIds, localLocations, depthOptions, isIgnoreExternals, null);
+        }
 
         public static List<ModuleLocation> parse(String[] remoteLocations, String[] credentialIds,
                                                  String[] localLocations, String[] depthOptions,

--- a/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
+++ b/src/main/java/hudson/scm/subversion/CheckoutUpdater.java
@@ -95,7 +95,8 @@ public class CheckoutUpdater extends WorkspaceUpdater {
 
                     File local = new File(ws, location.getLocalDir());
                     SubversionUpdateEventHandler eventHandler = new SubversionUpdateEventHandler(
-                        new PrintStream(pos), externals, local, location.getLocalDir(), quietOperation);
+                        new PrintStream(pos), externals, local, location.getLocalDir(), quietOperation,
+                        location.isCancelProcessOnExternalsFail());
                     svnuc.setEventHandler(eventHandler);
                     svnuc.setExternalsHandler(eventHandler);
                     svnuc.setIgnoreExternals(location.isIgnoreExternalsOption());

--- a/src/main/java/hudson/scm/subversion/SubversionUpdateEventHandler.java
+++ b/src/main/java/hudson/scm/subversion/SubversionUpdateEventHandler.java
@@ -63,10 +63,10 @@ final class SubversionUpdateEventHandler extends SubversionEventHandlerImpl impl
      */
     private final String modulePath;
 
-  /**
-   * Flag to cancel the process when checkout/update svn:externals failed.
-   */
-  private final boolean cancelProcessOnExternalsFailed;
+    /**
+     * Flag to cancel the process when checkout/update svn:externals failed.
+     */
+    private final boolean cancelProcessOnExternalsFailed;
 
     /**
      * @deprecated Use {@link #SubversionUpdateEventHandler(PrintStream, List, File, String, boolean, boolean)}
@@ -77,14 +77,14 @@ final class SubversionUpdateEventHandler extends SubversionEventHandlerImpl impl
         this(out, externals, moduleDir, modulePath, false, false);
     }
 
-  /**
-   * @deprecated Use {@link #SubversionUpdateEventHandler(PrintStream, List, File, String, boolean, boolean)}
-   */
-  @Deprecated
-  public SubversionUpdateEventHandler(PrintStream out, List<External> externals, File moduleDir,
-                                      String modulePath, boolean quietOperation) {
-    this(out, externals, moduleDir, modulePath, quietOperation, false);
-  }
+    /**
+     * @deprecated Use {@link #SubversionUpdateEventHandler(PrintStream, List, File, String, boolean, boolean)}
+     */
+    @Deprecated
+    public SubversionUpdateEventHandler(PrintStream out, List<External> externals, File moduleDir,
+                                        String modulePath, boolean quietOperation) {
+      this(out, externals, moduleDir, modulePath, quietOperation, false);
+    }
 
     /**
      * @since 2.10
@@ -94,7 +94,7 @@ final class SubversionUpdateEventHandler extends SubversionEventHandlerImpl impl
         super(out, moduleDir, quietOperation);
         this.externals = externals;
         this.modulePath = modulePath;
-      this.cancelProcessOnExternalsFailed = cancelProcessOnExternalsFailed;
+        this.cancelProcessOnExternalsFailed = cancelProcessOnExternalsFailed;
     }
 
     public SVNRevision[] handleExternal(File externalPath, SVNURL externalURL, SVNRevision externalRevision,
@@ -108,7 +108,7 @@ final class SubversionUpdateEventHandler extends SubversionEventHandlerImpl impl
         }
         SVNExternalDetails details = new SVNExternalDetails(externalURL, revisionNumber);
 
-      out.println("\n<-- Got one external: " + externalPath.getName() + ", svn url: " + details.getUrl() + " -->");
+        out.println("\n<-- Got one external: " + externalPath.getName() + ", svn url: " + details.getUrl() + " -->");
         externalDetails.put(externalPath, details);
         return new SVNRevision[] {externalRevision, externalPegRevision};
     }
@@ -131,17 +131,17 @@ final class SubversionUpdateEventHandler extends SubversionEventHandlerImpl impl
                 externals.add(new External(modulePath + '/' + path, details.getUrl(), details.getRevision()));
             }
         } else if (action == SVNEventAction.FAILED_EXTERNAL) {
-          File file = event.getFile();
-          SVNExternalDetails details = externalDetails.get(file);
-          if (details != null) {
-            out.println(Messages.SubversionUpdateEventHandler_FetchExternal(details.getUrl(), event.getRevision(), file)
-                + " failed!");
-          }
+            File file = event.getFile();
+            SVNExternalDetails details = externalDetails.get(file);
+            if (details != null) {
+              out.println(Messages.SubversionUpdateEventHandler_FetchExternal(details.getUrl(), event.getRevision(), file)
+                  + " failed!");
+            }
 
-          if (cancelProcessOnExternalsFailed) {
-            throw new SVNException(SVNErrorMessage.create(SVNErrorCode.CL_ERROR_PROCESSING_EXTERNALS,
-                SVNErrorCode.CL_ERROR_PROCESSING_EXTERNALS.getDescription() + ": <" + file.getName() + ">"));
-          }
+            if (cancelProcessOnExternalsFailed) {
+              throw new SVNException(SVNErrorMessage.create(SVNErrorCode.CL_ERROR_PROCESSING_EXTERNALS,
+                  SVNErrorCode.CL_ERROR_PROCESSING_EXTERNALS.getDescription() + ": <" + file.getName() + ">"));
+            }
         }
 
         super.handleEvent(event, progress);

--- a/src/main/java/hudson/scm/subversion/SubversionUpdateEventHandler.java
+++ b/src/main/java/hudson/scm/subversion/SubversionUpdateEventHandler.java
@@ -63,23 +63,38 @@ final class SubversionUpdateEventHandler extends SubversionEventHandlerImpl impl
      */
     private final String modulePath;
 
+  /**
+   * Flag to cancel the process when checkout/update svn:externals failed.
+   */
+  private final boolean cancelProcessOnExternalsFailed;
+
     /**
-     * @deprecated Use {@link #SubversionUpdateEventHandler(PrintStream, List, File, String, boolean)}
+     * @deprecated Use {@link #SubversionUpdateEventHandler(PrintStream, List, File, String, boolean, boolean)}
      */
     @Deprecated
     public SubversionUpdateEventHandler(PrintStream out, List<External> externals, File moduleDir,
                                         String modulePath) {
-        this(out, externals, moduleDir, modulePath, false);
+        this(out, externals, moduleDir, modulePath, false, false);
     }
+
+  /**
+   * @deprecated Use {@link #SubversionUpdateEventHandler(PrintStream, List, File, String, boolean, boolean)}
+   */
+  @Deprecated
+  public SubversionUpdateEventHandler(PrintStream out, List<External> externals, File moduleDir,
+                                      String modulePath, boolean quietOperation) {
+    this(out, externals, moduleDir, modulePath, quietOperation, false);
+  }
 
     /**
      * @since 2.10
      */
     public SubversionUpdateEventHandler(PrintStream out, List<External> externals, File moduleDir,
-                                        String modulePath, boolean quietOperation) {
+                                        String modulePath, boolean quietOperation, boolean cancelProcessOnExternalsFailed) {
         super(out, moduleDir, quietOperation);
         this.externals = externals;
         this.modulePath = modulePath;
+      this.cancelProcessOnExternalsFailed = cancelProcessOnExternalsFailed;
     }
 
     public SVNRevision[] handleExternal(File externalPath, SVNURL externalURL, SVNRevision externalRevision,
@@ -93,6 +108,7 @@ final class SubversionUpdateEventHandler extends SubversionEventHandlerImpl impl
         }
         SVNExternalDetails details = new SVNExternalDetails(externalURL, revisionNumber);
 
+      out.println("\n<-- Got one external: " + externalPath.getName() + ", svn url: " + details.getUrl() + " -->");
         externalDetails.put(externalPath, details);
         return new SVNRevision[] {externalRevision, externalPegRevision};
     }
@@ -114,6 +130,18 @@ final class SubversionUpdateEventHandler extends SubversionEventHandlerImpl impl
                 out.println(Messages.SubversionUpdateEventHandler_FetchExternal(details.getUrl(), event.getRevision(), file));
                 externals.add(new External(modulePath + '/' + path, details.getUrl(), details.getRevision()));
             }
+        } else if (action == SVNEventAction.FAILED_EXTERNAL) {
+          File file = event.getFile();
+          SVNExternalDetails details = externalDetails.get(file);
+          if (details != null) {
+            out.println(Messages.SubversionUpdateEventHandler_FetchExternal(details.getUrl(), event.getRevision(), file)
+                + " failed!");
+          }
+
+          if (cancelProcessOnExternalsFailed) {
+            throw new SVNException(SVNErrorMessage.create(SVNErrorCode.CL_ERROR_PROCESSING_EXTERNALS,
+                SVNErrorCode.CL_ERROR_PROCESSING_EXTERNALS.getDescription() + ": <" + file.getName() + ">"));
+          }
         }
 
         super.handleEvent(event, progress);

--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -140,7 +140,8 @@ public class UpdateUpdater extends WorkspaceUpdater {
             try {
                 File local = new File(ws, location.getLocalDir());
                 SubversionUpdateEventHandler eventHandler = new SubversionUpdateEventHandler(
-                    listener.getLogger(), externals, local, location.getLocalDir(), quietOperation);
+                    listener.getLogger(), externals, local, location.getLocalDir(), quietOperation,
+                    location.isCancelProcessOnExternalsFail());
                 svnuc.setEventHandler(eventHandler);
                 svnuc.setExternalsHandler(eventHandler);
 

--- a/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/config.jelly
@@ -55,9 +55,9 @@ THE SOFTWARE.
   <f:entry title="${%Ignore externals}" field="ignoreExternalsOption">
     <f:checkbox default="true"/>
   </f:entry>
-    <f:entry title="${%Cancel process on externals fail}" field="cancelProcessOnExternalsFail">
-        <f:checkbox default="true"/>
-    </f:entry>
+  <f:entry title="${%Cancel process on externals fail}" field="cancelProcessOnExternalsFail">
+    <f:checkbox default="true"/>
+  </f:entry>
   <f:entry>
     <div align="right">
       <input type="button" value="${%Delete}" class="repeatable-delete show-if-not-only" style="margin-left: 1em;"/>

--- a/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/config.jelly
@@ -55,6 +55,9 @@ THE SOFTWARE.
   <f:entry title="${%Ignore externals}" field="ignoreExternalsOption">
     <f:checkbox default="true"/>
   </f:entry>
+    <f:entry title="${%Cancel process on externals fail}" field="cancelProcessOnExternalsFail">
+        <f:checkbox default="true"/>
+    </f:entry>
   <f:entry>
     <div align="right">
       <input type="button" value="${%Delete}" class="repeatable-delete show-if-not-only" style="margin-left: 1em;"/>

--- a/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/help-cancelProcessOnExternalsFail.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/help-cancelProcessOnExternalsFail.html
@@ -1,0 +1,3 @@
+<div>
+    Determines if the process should be cancelled when checkout/update svn:externals failed. Will work when "Ignore externals" box is not checked.
+</div>

--- a/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/help-cancelProcessOnExternalsFail.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/help-cancelProcessOnExternalsFail.html
@@ -1,3 +1,4 @@
 <div>
     Determines if the process should be cancelled when checkout/update svn:externals failed. Will work when "Ignore externals" box is not checked.
+    Default choice is to cancelled the process when checkout/update svn:externals failed.
 </div>


### PR DESCRIPTION
which determines if the process should be cancelled when checkout/update svn:externals failed.

Sometimes, when svn:externals checkout/update failed, the artifacts generated is likely to fall short of expectations, but now it's ignored by default and no message can found in the log.