### PR TITLE
[JENKINS-41626] Fix path detection when subfolder older than root folder

### DIFF
--- a/src/main/java/jenkins/scm/impl/subversion/SubversionSCMSource.java
+++ b/src/main/java/jenkins/scm/impl/subversion/SubversionSCMSource.java
@@ -243,7 +243,6 @@ public class SubversionSCMSource extends SCMSource {
             List<String> prefix = Collections.emptyList();
             fetch(listener,
                     repository,
-                    -1,
                     repoPath,
                     toPaths(splitCludes(includes)),
                     prefix,
@@ -343,7 +342,6 @@ public class SubversionSCMSource extends SCMSource {
 
     void fetch(@NonNull TaskListener listener,
                @NonNull final SVNRepositoryView repository,
-               long rev,
                @NonNull final String repoPath,
                @NonNull SortedSet<List<String>> paths,
                @NonNull List<String> prefix,
@@ -356,8 +354,8 @@ public class SubversionSCMSource extends SCMSource {
         assert prefix.size() == realPath.size();
         assert wildcardStartsWith(realPath, prefix);
         SortedMap<List<String>, SortedSet<List<String>>> includePaths = groupPaths(paths, prefix);
-        listener.getLogger().println("Checking directory " + svnPath + (rev > -1 ? "@" + rev : "@HEAD"));
-        SVNRepositoryView.NodeEntry node = repository.getNode(svnPath, rev);
+        listener.getLogger().println("Checking directory " + svnPath + "@HEAD");
+        SVNRepositoryView.NodeEntry node = repository.getNode(svnPath, -1);
         if (!SVNNodeKind.DIR.equals(node.getType()) || node.getChildren() == null) {
             return;
         }
@@ -424,8 +422,7 @@ public class SubversionSCMSource extends SCMSource {
                                 listener.getLogger().println("Does not meet criteria");
                             }
                         } else {
-                            fetch(listener, repository, -1, repoPath, paths,
-                                    childPrefix,
+                            fetch(listener, repository, repoPath, paths, childPrefix,
                                     childRealPath, excludedPaths, branchCriteria, observer);
                         }
                     }


### PR DESCRIPTION
This is based on comments in the JIRA issue and some additional investigation.  I think I have the interaction with the `SCMHeadObserver` working correctly.

In the diagram in the JIRA issue, the directory containing Jenkinsfile is at an older revision than the root directory of the scan.  This results in subversion not resolving the path since a directory in the middle of the path tree didn't exist in that specific revision.  The simple fix it so just always scan using HEAD, however that means that any notifications to the `SCMHeadObserver` wouldn't contain a valid revision.  This fix scans using HEAD, and then once it finds the Jenkinsfile checks if the specific revision would have worked.  If it did, then it assumes that it needs to notify the observer using that revision.  If the final check fails, then it assumes that the branch is newly created and that it cannot notify using a specific revision since the checkout itself will probably fail (I didn't test that part).  In this case it notifies with the HEAD revision and assumes since the branch is new the specific revision doesn't matter.