### PR TITLE
[FIX JENKINS-50861] update core and Pipeline scm step dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,9 +138,10 @@ THE SOFTWARE.
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
-    <workflow.version>1.14.2</workflow.version>
+    <workflow-scm-step.version>2.6</workflow-scm-step.version>
+    <workflow-aggregator.version>2.5</workflow-aggregator.version>
     <findbugs.failOnError>false</findbugs.failOnError> <!-- TODO still have 27 left -->
-    <scm-api-plugin.version>2.0.8</scm-api-plugin.version>
+    <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
   </properties>
 
   <repositories>
@@ -176,12 +177,18 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.15</version>
+      <version>2.1.16</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>structs</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.11</version>
+      <version>1.12</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -191,7 +198,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-scm-step</artifactId>
-      <version>${workflow.version}</version>
+      <version>${workflow-scm-step.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>
@@ -256,9 +263,18 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-aggregator</artifactId>
-      <version>${workflow.version}</version>
-      <classifier>tests</classifier>
+      <version>${workflow-aggregator.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins.workflow</groupId>
+          <artifactId>workflow-step-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins.workflow</groupId>
+          <artifactId>workflow-scm-step</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
   </parent>
 
   <artifactId>subversion</artifactId>
-  <version>2.10.5</version>
+  <version>2.10.6-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Jenkins Subversion Plug-in</name>
@@ -131,7 +131,7 @@ THE SOFTWARE.
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>subversion-2.10.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -269,10 +269,6 @@ THE SOFTWARE.
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-step-api</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>script-security</artifactId>
-      </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@ THE SOFTWARE.
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
+    <!-- TODO if both workflow-* versions are the same we would remove one of the properties -->
     <workflow-scm-step.version>2.6</workflow-scm-step.version>
     <workflow-aggregator.version>2.5</workflow-aggregator.version>
     <findbugs.failOnError>false</findbugs.failOnError> <!-- TODO still have 27 left -->
@@ -178,12 +179,11 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
       <version>2.1.16</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>structs</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.9</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -135,12 +135,13 @@ THE SOFTWARE.
   </scm>
 
   <properties>
-    <jenkins.version>2.7.3</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.60</jenkins.version>
+    <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
-    <workflow.version>1.14.2</workflow.version>
+    <workflow-scm-step.version>2.3</workflow-scm-step.version>
+    <workflow-aggregator.version>2.5</workflow-aggregator.version>
     <findbugs.failOnError>false</findbugs.failOnError> <!-- TODO still have 27 left -->
-    <scm-api-plugin.version>2.0.8</scm-api-plugin.version>
+    <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
   </properties>
 
   <repositories>
@@ -176,7 +177,13 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.15</version>
+      <version>2.1.16</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>structs</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -191,7 +198,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-scm-step</artifactId>
-      <version>${workflow.version}</version>
+      <version>${workflow-scm-step.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>
@@ -256,7 +263,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-aggregator</artifactId>
-      <version>${workflow.version}</version>
+      <version>${workflow-aggregator.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.11</version>
+      <version>1.12</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -206,7 +206,6 @@ THE SOFTWARE.
         </exclusion>
       </exclusions>
     </dependency>
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
@@ -264,8 +263,17 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-aggregator</artifactId>
       <version>${workflow-aggregator.version}</version>
-      <classifier>tests</classifier>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins.workflow</groupId>
+          <artifactId>workflow-step-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>script-security</artifactId>
+      </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/jenkins/scm/impl/subversion/SubversionSCMSource.java
+++ b/src/main/java/jenkins/scm/impl/subversion/SubversionSCMSource.java
@@ -231,7 +231,8 @@ public class SubversionSCMSource extends SCMSource {
     protected void retrieve(@CheckForNull SCMSourceCriteria criteria,
                             @NonNull final SCMHeadObserver observer,
                             @CheckForNull SCMHeadEvent<?> event,
-                            @NonNull TaskListener listener) throws IOException, InterruptedException {
+                            @NonNull TaskListener listener) 
+                            throws IOException, InterruptedException {
         SVNRepositoryView repository = null;
         try {
             listener.getLogger().println("Opening conection to " + remoteBase);

--- a/src/main/java/jenkins/scm/impl/subversion/SubversionSCMSource.java
+++ b/src/main/java/jenkins/scm/impl/subversion/SubversionSCMSource.java
@@ -231,8 +231,7 @@ public class SubversionSCMSource extends SCMSource {
     protected void retrieve(@CheckForNull SCMSourceCriteria criteria,
                             @NonNull final SCMHeadObserver observer,
                             @CheckForNull SCMHeadEvent<?> event,
-                            @NonNull TaskListener listener)
-            throws IOException {
+                            @NonNull TaskListener listener) throws IOException, InterruptedException {
         SVNRepositoryView repository = null;
         try {
             listener.getLogger().println("Opening conection to " + remoteBase);
@@ -348,8 +347,7 @@ public class SubversionSCMSource extends SCMSource {
                @NonNull List<String> realPath,
                @NonNull SortedSet<List<String>> excludedPaths,
                @CheckForNull SCMSourceCriteria branchCriteria,
-               @NonNull SCMHeadObserver observer)
-            throws IOException, SVNException {
+               @NonNull SCMHeadObserver observer) throws IOException, SVNException, InterruptedException {
         String svnPath = SVNPathUtil.append(repoPath, StringUtils.join(realPath, '/'));
         assert prefix.size() == realPath.size();
         assert wildcardStartsWith(realPath, prefix);


### PR DESCRIPTION
[JENKINS-50861](https://issues.jenkins-ci.org/browse/JENKINS-50861)

* Update Pipeline SCM step to 2.3
* Update Pipeline to 2.5 for test
* Update core to 2.60
* Update Java to 8
* Update SCM API  to 2.2.6
* Update credentials to 2.1.16
* fix inherited dependencies
* propagate new exceptions

@reviewbybees 