### PR TITLE
java 8 required for presence of lambdas and svnkit to 1.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,8 +135,8 @@ THE SOFTWARE.
   </scm>
 
   <properties>
-    <jenkins.version>2.7.3</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.54</jenkins.version>
+    <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
     <workflow.version>1.14.2</workflow.version>
     <findbugs.failOnError>false</findbugs.failOnError> <!-- TODO still have 27 left -->
@@ -160,12 +160,12 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.tmatesoft.svnkit</groupId>
       <artifactId>svnkit</artifactId>
-      <version>1.9.1</version>
+      <version>1.9.2</version>
     </dependency>
     <dependency>
       <groupId>org.tmatesoft.svnkit</groupId>
       <artifactId>svnkit-cli</artifactId>
-      <version>1.9.1</version>
+      <version>1.9.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@ THE SOFTWARE.
   </scm>
 
   <properties>
-    <jenkins.version>2.54</jenkins.version>
+    <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
     <workflow.version>1.14.2</workflow.version>


### PR DESCRIPTION
It is currently impossible to build because there are lambdas in recent commits that require java 8. We are also using svnkit 1.9.2 without problems and all unit tests pass