### PR TITLE
[JENKINS-50457] Convert anonymous classes to members

### DIFF
--- a/src/main/java/hudson/scm/SubversionWorkspaceSelector.java
+++ b/src/main/java/hudson/scm/SubversionWorkspaceSelector.java
@@ -110,13 +110,7 @@ public class SubversionWorkspaceSelector implements ISVNAdminAreaFactorySelector
             Channel c = Channel.current();
             if (c!=null)    // just being defensive. cannot be null.
                 try {
-                    workspaceFormat = c.call(new SlaveToMasterCallable<Integer, RuntimeException>() { // TODO JENKINS-48543 bad design
-                        private static final long serialVersionUID = 6494337549896104453L;
-
-                        public Integer call()  {
-                            return Hudson.getInstance().getDescriptorByType(SubversionSCM.DescriptorImpl.class).getWorkspaceFormat();
-                        }
-                    });
+                    workspaceFormat = c.call(new GetWorkspaceFormatSlaveToMasterCallable());
                 } catch (IOException e) {
                     LOGGER.log(Level.WARNING, "Failed to retrieve Subversion workspace format",e);
                 } catch (InterruptedException e) {
@@ -139,4 +133,12 @@ public class SubversionWorkspaceSelector implements ISVNAdminAreaFactorySelector
     public static final int OLD_WC_FORMAT_17 = 100;
 
     private static final Logger LOGGER = Logger.getLogger(SubversionWorkspaceSelector.class.getName());
+
+    private static class GetWorkspaceFormatSlaveToMasterCallable extends SlaveToMasterCallable<Integer, RuntimeException> {  // TODO JENKINS-48543 bad design
+        private static final long serialVersionUID = 6494337549896104453L;
+
+        public Integer call()  {
+            return Hudson.getInstance().getDescriptorByType(SubversionSCM.DescriptorImpl.class).getWorkspaceFormat();
+        }
+    }
 }


### PR DESCRIPTION
WARNING: Attempt to (de-)serialize anonymous class hudson.scm.subversion.CheckoutUpdater$1
WARNING: Attempt to (de-)serialize anonymous class hudson.scm.SubversionWorkspaceSelector$1

see: https://jenkins.io/redirect/serialization-of-anonymous-classes/

See [JENKINS-50457](https://issues.jenkins-ci.org/browse/JENKINS-50457).
