### PR TITLE
[JENKINS-53325] Exclude trilead-ssh2 dependency on svnkit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,12 @@ THE SOFTWARE.
       <groupId>org.tmatesoft.svnkit</groupId>
       <artifactId>svnkit</artifactId>
       <version>1.9.3</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.trilead</groupId>
+          <artifactId>trilead-ssh2</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.tmatesoft.svnkit</groupId>


### PR DESCRIPTION
[JENKINS-53325](https://issues.jenkins-ci.org/browse/JENKINS-53325)

* Exclude trilead-ssh2 dependency on svnkit