### PR TITLE
[JENKINS-53325] Use trilead classes from Jenkins core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@ THE SOFTWARE.
   </scm>
 
   <properties>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.73.3</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
     <!-- TODO if both workflow-* versions are the same we would remove one of the properties -->
@@ -302,7 +302,6 @@ THE SOFTWARE.
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
         <configuration>
-          <maskClasses>com.trilead.ssh2.</maskClasses>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION

* Update Jenkins core version to 2.73.3
* Remove <maskClasses>com.trilead.ssh2</maskClasses>

[JENKINS-53325](https://issues.jenkins-ci.org/browse/JENKINS-53325)