### PR TITLE
[JENKINS-17228] Fail build when subversion workspace is locked

### DIFF
--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -183,8 +183,8 @@ public class UpdateUpdater extends WorkspaceUpdater {
                     SVNErrorCode errorCode = cause.getErrorMessage().getErrorCode();
                     if (errorCode == SVNErrorCode.WC_LOCKED) {
                         // work space locked. try fresh check out
-                        listener.getLogger().println("Workspace appear to be locked, so getting a fresh workspace");
-                        return delegateTo(new CheckoutUpdater());
+                        listener.getLogger().println("Workspace appear to be locked, so Failing the build");
+                        throw (InterruptedException) new InterruptedException().initCause(e);
                     }
                     if (errorCode == SVNErrorCode.WC_OBSTRUCTED_UPDATE) {
                         // HUDSON-1882. If existence of local files cause an update to fail,


### PR DESCRIPTION
As pointed out in https://issues.jenkins-ci.org/browse/JENKINS-17228 , getting fresh copy just because the workspace is locked is problematic, especially with large repos (checkout and rebuild times can be in hours).
The fix is taken from the same file in Hudson repo. Specific commit can be seen here: https://github.com/hudson3-plugins/subversion-plugin/commit/37ca9c134702878e6bb824dde108d63c6df043d8