### PR TITLE
Minor code cleanup

### DIFF
--- a/src/main/java/hudson/scm/DirAwareSVNXMLLogHandler.java
+++ b/src/main/java/hudson/scm/DirAwareSVNXMLLogHandler.java
@@ -12,7 +12,6 @@
 package hudson.scm;
 
 import java.io.File;
-import java.util.Iterator;
 import java.util.LinkedList;
 
 import jenkins.scm.impl.subversion.RemotableSVNErrorMessage;

--- a/src/main/java/hudson/scm/SubversionChangeLogSet.java
+++ b/src/main/java/hudson/scm/SubversionChangeLogSet.java
@@ -40,7 +40,9 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+
 import jenkins.triggers.SCMTriggerItem;
 
 import org.kohsuke.accmod.Restricted;
@@ -373,13 +375,13 @@ public final class SubversionChangeLogSet extends ChangeLogSet<LogEntry> {
             if (revision != that.revision) {
                 return false;
             }
-            if (author != null ? !author.equals(that.author) : that.author != null) {
+            if (!Objects.equals(author, that.author)) {
                 return false;
             }
-            if (date != null ? !date.equals(that.date) : that.date != null) {
+            if (!Objects.equals(date, that.date)) {
                 return false;
             }
-            if (msg != null ? !msg.equals(that.msg) : that.msg != null) {
+            if (!Objects.equals(msg, that.msg)) {
                 return false;
             }
 

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -64,7 +64,6 @@ import hudson.FilePath.FileCallable;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.init.InitMilestone;
-import hudson.model.*;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.UnsupportedCharsetException;
@@ -72,11 +71,23 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.WeakHashMap;
 
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.AbstractProject;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.model.JobProperty;
+import hudson.model.ModelObject;
+import hudson.model.Node;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.util.ListBoxModel;
@@ -112,18 +123,23 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.UUID;
+import java.util.WeakHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -923,8 +939,7 @@ public class SubversionSCM extends SCM implements Serializable {
         for (ModuleLocation location : getLocations(env, build)) {
             CheckOutTask checkOutTask =
                     new CheckOutTask(build, this, location, build.getTimestamp().getTime(), listener, env, quietOperation);
-            List<External> externals = new ArrayList<>();
-            externals.addAll(workspace.act(checkOutTask));
+            List<External> externals = new ArrayList<>(workspace.act(checkOutTask));
             // save location <---> externals maps
             externalsMap.put(location.remote, externals);
             unauthenticatedRealms.addAll(checkOutTask.getUnauthenticatedRealms());
@@ -1481,7 +1496,7 @@ public class SubversionSCM extends SCM implements Serializable {
         private SVNLogFilter filter;
 
         SVNLogHandler(SVNLogFilter svnLogFilter, TaskListener listener) {
-            this.filter = svnLogFilter;;
+            this.filter = svnLogFilter;
             this.filter.setTaskListener(listener);
         }
 
@@ -3369,7 +3384,7 @@ public class SubversionSCM extends SCM implements Serializable {
             if (!realm.equals(that.realm)) {
                 return false;
             }
-            if (credentialsId != null ? !credentialsId.equals(that.credentialsId) : that.credentialsId != null) {
+            if (!Objects.equals(credentialsId, that.credentialsId)) {
                 return false;
             }
 

--- a/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterValue.java
+++ b/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterValue.java
@@ -33,6 +33,8 @@ import hudson.util.VariableResolver;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.export.Exported;
 
+import java.util.Objects;
+
 /**
  * This class represents the actual {@link ParameterValue} for the
  * {@link ListSubversionTagsParameterDefinition} parameter.
@@ -73,10 +75,8 @@ public class ListSubversionTagsParameterValue extends ParameterValue {
 
     ListSubversionTagsParameterValue that = (ListSubversionTagsParameterValue) o;
 
-    if (tag != null ? !tag.equals(that.tag) : that.tag != null) return false;
-    if (tagsDir != null ? !tagsDir.equals(that.tagsDir) : that.tagsDir != null) return false;
-
-    return true;
+    if (!Objects.equals(tag, that.tag)) return false;
+    return Objects.equals(tagsDir, that.tagsDir);
   }
 
   @Override

--- a/src/test/java/hudson/scm/DefaultSVNLogFilterTest.java
+++ b/src/test/java/hudson/scm/DefaultSVNLogFilterTest.java
@@ -76,7 +76,7 @@ public class DefaultSVNLogFilterTest extends AbstractSubversionTest {
     public void noExcludes() throws Exception {
         
         DefaultSVNLogFilter filter = new DefaultSVNLogFilter(noPatterns, noPatterns, noUsers, null, noPatterns, false);
-        assertTrue(!filter.hasExclusionRule());
+        assertFalse(filter.hasExclusionRule());
         
         List<SVNLogEntry> entries = doFilter(filter);
         assertTrue(containsRevs(entries, 1, 2, 3, 4, 5));

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -1618,7 +1618,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
             assertTrue(ws.child("with_externals").child("externals").child("projb").exists());
 
             // Check that the external doesn't exist
-            assertTrue(!(ws.child("no_externals").child("externals").child("projb").exists()));
+            assertFalse(ws.child("no_externals").child("externals").child("projb").exists());
         } finally {
             p.kill();
         }

--- a/src/test/java/jenkins/scm/impl/subversion/SubversionSCMFileSystemTest.java
+++ b/src/test/java/jenkins/scm/impl/subversion/SubversionSCMFileSystemTest.java
@@ -94,7 +94,7 @@ public class SubversionSCMFileSystemTest {
 		long oneMinute = 60*1000;
 		sampleRepo.write("file", "modified");
 		sampleRepo.svnkit("commit", "--message=dev1", sampleRepo.wc());
-		try (SCMFileSystem fs = SCMFileSystem.of(source, new SCMHead("branches/dev"), revision);) {			
+		try (SCMFileSystem fs = SCMFileSystem.of(source, new SCMHead("branches/dev"), revision)) {			
 			long lastModified = fs.lastModified();
 			//ensure the timestamp is from after we started but not in the distant future
 			assertThat(lastModified, greaterThanOrEqualTo(currentTime));
@@ -156,7 +156,7 @@ public class SubversionSCMFileSystemTest {
 		sampleRepo.svnkit("add", sampleRepo.wc() + "/dir");
 		sampleRepo.svnkit("commit", "--message=dev1", sampleRepo.wc());
 		SCMSource source = new SubversionSCMSource(null, sampleRepo.prjUrl());
-		try (SCMFileSystem fs = SCMFileSystem.of(source, new SCMHead("branches/dev"));) {
+		try (SCMFileSystem fs = SCMFileSystem.of(source, new SCMHead("branches/dev"))) {
 			assertThat(fs, notNullValue());
 			assertThat(fs.getRoot(), notNullValue());
 			Iterable<SCMFile> children = fs.getRoot().children();

--- a/src/test/java/jenkins/scm/impl/subversion/SubversionSCMSourceTest.java
+++ b/src/test/java/jenkins/scm/impl/subversion/SubversionSCMSourceTest.java
@@ -1,6 +1,5 @@
 package jenkins.scm.impl.subversion;
 
-import jenkins.scm.impl.subversion.SubversionSCMSource;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -20,7 +19,7 @@ import static org.junit.Assert.assertThat;
 public class SubversionSCMSourceTest {
 
     @Test
-    public void isMatch() throws Exception {
+    public void isMatch() {
         assertThat(SubversionSCMSource.isMatch("trunk", "trunk"), is(true));
         assertThat(SubversionSCMSource.isMatch("trunk", "trunk*"), is(true));
         assertThat(SubversionSCMSource.isMatch("trunk", "*trunk"), is(true));
@@ -32,17 +31,17 @@ public class SubversionSCMSourceTest {
     }
 
     @Test
-    public void splitCludes() throws Exception {
+    public void splitCludes() {
         assertThat(SubversionSCMSource.splitCludes("trunk"),
-                is((SortedSet) new TreeSet<>(Arrays.asList("trunk"))));
+                is(new TreeSet<>(Collections.singletonList("trunk"))));
         assertThat(SubversionSCMSource.splitCludes("trunk,branches/*"),
-                is((SortedSet) new TreeSet<>(Arrays.asList("trunk", "branches/*"))));
+                is(new TreeSet<>(Arrays.asList("trunk", "branches/*"))));
         assertThat(SubversionSCMSource.splitCludes("trunk, branches/*"),
-                is((SortedSet) new TreeSet<>(Arrays.asList("trunk", "branches/*"))));
+                is(new TreeSet<>(Arrays.asList("trunk", "branches/*"))));
         assertThat(SubversionSCMSource.splitCludes("trunk , , branches/*"),
-                is((SortedSet) new TreeSet<>(Arrays.asList("trunk", "branches/*"))));
+                is(new TreeSet<>(Arrays.asList("trunk", "branches/*"))));
         assertThat(SubversionSCMSource.splitCludes("trunk , , branches/*   , tags/* "),
-                is((SortedSet) new TreeSet<>(Arrays.asList("trunk", "branches/*", "tags/*"))));
+                is(new TreeSet<>(Arrays.asList("trunk", "branches/*", "tags/*"))));
     }
 
     private static List<String> list(String... values) {
@@ -56,7 +55,7 @@ public class SubversionSCMSourceTest {
     }
 
     @Test
-    public void toPaths() throws Exception {
+    public void toPaths() {
         assertThat(SubversionSCMSource.toPaths(SubversionSCMSource.splitCludes("trunk")), is(pathSet(list("trunk"))));
         assertThat(SubversionSCMSource.toPaths(SubversionSCMSource.splitCludes("trunk,branches/*")), is(pathSet(
                 list("trunk"), list("branches", "*")
@@ -69,7 +68,7 @@ public class SubversionSCMSourceTest {
     }
 
     @Test
-    public void filterPaths() throws Exception {
+    public void filterPaths() {
         assertThat(SubversionSCMSource
                 .filterPaths(pathSet(list("trunk"), list("branches", "foo"), list("branches", "bar")),
                         list("trunk")),
@@ -81,7 +80,7 @@ public class SubversionSCMSourceTest {
     }
 
     @Test
-    public void groupPaths() throws Exception {
+    public void groupPaths() {
         SortedMap<List<String>, SortedSet<List<String>>> result;
         SortedSet<List<String>> data = pathSet(
                 list("trunk"),
@@ -135,7 +134,7 @@ public class SubversionSCMSourceTest {
     }
 
     @Test
-    public void startsWith() throws Exception {
+    public void startsWith() {
         assertThat(SubversionSCMSource.startsWith(list(), list()), is(true));
         assertThat(SubversionSCMSource.startsWith(list("a", "b", "c"), list()), is(true));
         assertThat(SubversionSCMSource.startsWith(list("a", "b", "c"), list("a")), is(true));
@@ -148,7 +147,7 @@ public class SubversionSCMSourceTest {
     }
 
     @Test
-    public void wildcardStartsWith() throws Exception {
+    public void wildcardStartsWith() {
         assertThat(SubversionSCMSource.wildcardStartsWith(list(), list()), is(true));
         assertThat(SubversionSCMSource.wildcardStartsWith(list("a", "b", "c"), list()), is(true));
         assertThat(SubversionSCMSource.wildcardStartsWith(list("a", "b", "c"), list("a")), is(true));


### PR DESCRIPTION
Just some minor code cleanups:
* removed superfluous semicolons
* Introduced Object equals
* simplified asserts
* removed unneeded throws Exceptions
* replaced * imports