### PR TITLE
[JENKINS-62278] Jenkins.MANAGE access global config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.54</version>
+    <version>4.1</version>
     <relativePath />
   </parent>
 
@@ -135,13 +135,15 @@ THE SOFTWARE.
   </scm>
 
   <properties>
-    <jenkins.version>2.107.3</jenkins.version>
+    <jenkins.version>2.222.3</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
     <workflow-scm-step.version>2.6</workflow-scm-step.version>
     <workflow-aggregator.version>2.5</workflow-aggregator.version>
     <findbugs.failOnError>false</findbugs.failOnError> <!-- TODO still have 27 left -->
     <scm-api-plugin.version>2.6.3</scm-api-plugin.version>
+    <!-- To be removed once Jenkins.MANAGE gets out of beta -->
+    <useBeta>true</useBeta>
   </properties>
 
   <repositories>
@@ -210,6 +212,12 @@ THE SOFTWARE.
           <artifactId>httpclient</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <!-- Extracted from core at 2.190.1 -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>trilead-api</artifactId>
+      <version>1.0.6</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ THE SOFTWARE.
     <no-test-jar>false</no-test-jar>
     <workflow-scm-step.version>2.6</workflow-scm-step.version>
     <workflow-aggregator.version>2.5</workflow-aggregator.version>
-    <findbugs.failOnError>false</findbugs.failOnError> <!-- TODO still have 27 left -->
+    <spotbugs.failOnError>false</spotbugs.failOnError> <!-- TODO still have 27 left -->
     <scm-api-plugin.version>2.6.3</scm-api-plugin.version>
     <!-- To be removed once Jenkins.MANAGE gets out of beta -->
     <useBeta>true</useBeta>

--- a/pom.xml
+++ b/pom.xml
@@ -257,12 +257,6 @@ THE SOFTWARE.
       <artifactId>workflow-cps</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- Extracted from core at 2.190.1 -->
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>trilead-api</artifactId>
-      <version>1.0.6</version>
-    </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -79,6 +79,7 @@ import java.util.WeakHashMap;
 
 import hudson.security.ACL;
 import hudson.security.ACLContext;
+import hudson.security.Permission;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import hudson.remoting.Channel;
@@ -2195,6 +2196,12 @@ public class SubversionSCM extends SCM implements Serializable {
             for (int i = 0; i < xl.length; i++)
                 if (!xl[i].getURL().equals(yl[i].getURL())) return false;
             return true;
+        }
+
+        @Nonnull
+        @Override
+        public Permission getRequiredGlobalConfigPagePermission() {
+            return Jenkins.MANAGE;
         }
 
         /**

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -833,16 +833,16 @@ public class SubversionSCMTest extends AbstractSubversionTest {
         FreeStyleBuild bQuiet = r.assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause()).get());
         List<String> logsQuiet = bQuiet.getLog(LOG_LIMIT);
         //  This line in log should end with --quiet
-        assertTrue(logsQuiet.get(4).endsWith("--quiet"));
-        assertEquals("At revision 1", logsQuiet.get(5));
+        assertTrue(logsQuiet.get(5).endsWith("--quiet"));
+        assertEquals("At revision 1", logsQuiet.get(6));
 
         local.setQuietOperation(false);
         FreeStyleBuild bVerbose = r.assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause()).get());
         List<String> logsVerbose = bVerbose.getLog(LOG_LIMIT);
         //  This line in log should NOT end with --quiet
-        assertFalse(logsVerbose.get(4).endsWith("--quiet"));
-        assertTrue(logsVerbose.get(5).endsWith("readme.txt"));
-        assertEquals("At revision 1", logsVerbose.get(6));
+        assertFalse(logsVerbose.get(5).endsWith("--quiet"));
+        assertTrue(logsVerbose.get(6).endsWith("readme.txt"));
+        assertEquals("At revision 1", logsVerbose.get(7));
     }
     
     /**


### PR DESCRIPTION
[JENKINS-62278](https://issues.jenkins-ci.org/browse/JENKINS-62278)

Users with `Jenkins.MANAGE` should be able to configure global settings.
(`Jenkins.MANAGE` requires a core bump, and I'm also updating the parent).