### PR TITLE
replaced deprecated jenkins.getInstance with replacements and minor cleanup

### DIFF
--- a/src/main/java/hudson/scm/CompareAgainstBaselineCallable.java
+++ b/src/main/java/hudson/scm/CompareAgainstBaselineCallable.java
@@ -47,7 +47,7 @@ final class CompareAgainstBaselineCallable extends MasterToSlaveCallable<Polling
     }
 
     public ClassLoader getClassLoader() {
-        return Jenkins.getInstance().getPluginManager().uberClassLoader;
+        return Jenkins.get().getPluginManager().uberClassLoader;
     }
 
     /**

--- a/src/main/java/hudson/scm/SubversionChangeLogParser.java
+++ b/src/main/java/hudson/scm/SubversionChangeLogParser.java
@@ -27,7 +27,6 @@ import hudson.model.Run;
 import hudson.scm.SubversionChangeLogSet.LogEntry;
 import hudson.scm.SubversionChangeLogSet.Path;
 import hudson.util.Digester2;
-import jenkins.util.SystemProperties;
 import org.apache.commons.digester.Digester;
 import org.xml.sax.SAXException;
 

--- a/src/main/java/hudson/scm/SubversionCredentialProvider.java
+++ b/src/main/java/hudson/scm/SubversionCredentialProvider.java
@@ -59,6 +59,6 @@ public abstract class SubversionCredentialProvider implements ExtensionPoint {
      * All regsitered instances.
      */
     public static ExtensionList<SubversionCredentialProvider> all() {
-        return Jenkins.getInstance().getExtensionList(SubversionCredentialProvider.class);
+        return Jenkins.get().getExtensionList(SubversionCredentialProvider.class);
     }
 }

--- a/src/main/java/hudson/scm/SubversionEventHandlerImpl.java
+++ b/src/main/java/hudson/scm/SubversionEventHandlerImpl.java
@@ -227,7 +227,7 @@ public class SubversionEventHandlerImpl extends SVNEventAdapter {
 
     private static boolean equals(String p1, String p2) {
         if (SVNFileUtil.isWindows || SVNFileUtil.isOpenVMS) {
-            return p1.toLowerCase().equals(p2.toLowerCase());
+            return p1.equalsIgnoreCase(p2);
         }
         return p1.equals(p2);
     }

--- a/src/main/java/hudson/scm/SubversionRepositoryStatus.java
+++ b/src/main/java/hudson/scm/SubversionRepositoryStatus.java
@@ -162,7 +162,7 @@ public class SubversionRepositoryStatus {
         private JobProvider jobProvider = new JobProvider() {
             @SuppressWarnings("rawtypes")
             public List<Job> getAllJobs() {
-                return Jenkins.getInstance().getAllItems(Job.class);
+                return Jenkins.get().getAllItems(Job.class);
             }
         };
 

--- a/src/main/java/hudson/scm/SubversionTagAction.java
+++ b/src/main/java/hudson/scm/SubversionTagAction.java
@@ -326,7 +326,7 @@ public class SubversionTagAction extends AbstractScmTagAction implements Describ
     }
 
     public Descriptor<SubversionTagAction> getDescriptor() {
-        return Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**

--- a/src/main/java/hudson/scm/SubversionWorkspaceSelector.java
+++ b/src/main/java/hudson/scm/SubversionWorkspaceSelector.java
@@ -135,7 +135,7 @@ public class SubversionWorkspaceSelector implements ISVNAdminAreaFactorySelector
         private static final long serialVersionUID = 6494337549896104453L;
 
         public Integer call()  {
-            return Jenkins.getInstance().getDescriptorByType(SubversionSCM.DescriptorImpl.class).getWorkspaceFormat();
+            return Jenkins.get().getDescriptorByType(SubversionSCM.DescriptorImpl.class).getWorkspaceFormat();
         }
     }
 }

--- a/src/main/java/hudson/scm/UserProvidedCredential.java
+++ b/src/main/java/hudson/scm/UserProvidedCredential.java
@@ -94,7 +94,7 @@ public class UserProvidedCredential implements Closeable {
      * Parses the credential information from a form submission.
      */
     public static UserProvidedCredential fromForm(StaplerRequest req, MultipartFormDataParser parser) throws IOException {
-        CrumbIssuer crumbIssuer = Jenkins.getInstance().getCrumbIssuer();
+        CrumbIssuer crumbIssuer = Jenkins.get().getCrumbIssuer();
         if (crumbIssuer!=null && !crumbIssuer.validateCrumb(req, parser))
             throw HttpResponses.error(SC_FORBIDDEN,new IOException("No crumb found"));
 

--- a/src/main/java/hudson/scm/browsers/FishEyeSVN.java
+++ b/src/main/java/hudson/scm/browsers/FishEyeSVN.java
@@ -139,7 +139,7 @@ public class FishEyeSVN extends SubversionRepositoryBrowser {
                 return FormValidation.errorWithMarkup("The URL should end like <code>.../browse/foobar/</code>");
 
             // Connect to URL and check content only if we have admin permission
-            if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER))
+            if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER))
                 return FormValidation.ok();
 
             final String finalValue = value;

--- a/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition.java
+++ b/src/main/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition.java
@@ -379,7 +379,7 @@ public class ListSubversionTagsParameterDefinition extends ParameterDefinition {
 
     @CheckForNull
     public FormValidation doCheckTagsDir(StaplerRequest req, @AncestorInPath Item context, @QueryParameter String value) {
-        Jenkins instance = Jenkins.getInstance();
+        Jenkins instance = Jenkins.getInstanceOrNull();
         if (instance != null) {
             SubversionSCM.ModuleLocation.DescriptorImpl desc = instance.getDescriptorByType(SubversionSCM.ModuleLocation.DescriptorImpl.class);
             if (desc != null) {
@@ -394,7 +394,7 @@ public class ListSubversionTagsParameterDefinition extends ParameterDefinition {
       if (context == null || !context.hasPermission(Item.EXTENDED_READ)) {
         return new StandardListBoxModel();
       }
-      return Jenkins.getInstance().getDescriptorByType(
+      return Jenkins.get().getDescriptorByType(
               SubversionSCM.ModuleLocation.DescriptorImpl.class).fillCredentialsIdItems(context, tagsDir);
     }
 
@@ -404,7 +404,7 @@ public class ListSubversionTagsParameterDefinition extends ParameterDefinition {
       if (context == null || !context.hasPermission(CredentialsProvider.USE_ITEM)) {
         return FormValidation.ok();
       }
-      return Jenkins.getInstance().getDescriptorByType(
+      return Jenkins.get().getDescriptorByType(
               SubversionSCM.ModuleLocation.DescriptorImpl.class).checkCredentialsId(req, context, tagsDir, value);
     }
 
@@ -451,7 +451,7 @@ public class ListSubversionTagsParameterDefinition extends ParameterDefinition {
      */
     public SubversionSCM.DescriptorImpl getSubversionSCMDescriptor() {
       if(scmDescriptor == null) {
-        scmDescriptor = (SubversionSCM.DescriptorImpl) Jenkins.getInstance().getDescriptor(SubversionSCM.class);
+        scmDescriptor = (SubversionSCM.DescriptorImpl) Jenkins.get().getDescriptor(SubversionSCM.class);
       }
       return scmDescriptor;
     }

--- a/src/main/java/hudson/scm/subversion/WorkspaceUpdaterDescriptor.java
+++ b/src/main/java/hudson/scm/subversion/WorkspaceUpdaterDescriptor.java
@@ -35,6 +35,6 @@ import jenkins.model.Jenkins;
 public abstract class WorkspaceUpdaterDescriptor extends Descriptor<WorkspaceUpdater> {
 
     public static DescriptorExtensionList<WorkspaceUpdater,WorkspaceUpdaterDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(WorkspaceUpdater.class);
+        return Jenkins.get().getDescriptorList(WorkspaceUpdater.class);
     }
 }

--- a/src/main/java/jenkins/scm/impl/subversion/SVNRepositoryView.java
+++ b/src/main/java/jenkins/scm/impl/subversion/SVNRepositoryView.java
@@ -93,7 +93,7 @@ public class SVNRepositoryView {
             if (uuid == null) { // TODO is this even possible? Javadoc is unclear.
                 throw new IOException("Could not find UUID for " + repoURL);
             }
-            File cacheFile = new File(new File(Jenkins.getInstance().getRootDir(), "caches"), "svn-" + uuid + ".db");
+            File cacheFile = new File(new File(Jenkins.get().getRootDir(), "caches"), "svn-" + uuid + ".db");
 
             cacheFile.getParentFile().mkdirs();
             DB cache = null;


### PR DESCRIPTION
replaced deprecated `Jenkins.getInstance()` with replacements and minor cleanup