### PR TITLE
Update README.md [JENKINS-65132] Fix example script for notifyCommit

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,12 @@ example.
         # so we can present a valid crumb or a proper header
         HEADER="Content-Type:text/plain;charset=UTF-8"
         CRUMB=`$WGET --auth-no-challenge --output-document - ${CISERVER}/${CRUMB_ISSUER_URL}`
-        if [ "$CRUMB" != "" ]; then HEADER=$CRUMB; fi
+        if [ "$CRUMB" != "" ]; then CRUMB="--header $CRUMB"; fi
 
         $WGET \
             --auth-no-challenge \
             --header $HEADER \
+            $CRUMB
             --post-data "`$SVNLOOK changed --revision $REV $REPOS`" \
             --output-document "-"\
             --timeout=2 \

--- a/README.md
+++ b/README.md
@@ -149,14 +149,14 @@ example.
 
         # Check if "[X] Prevent Cross Site Request Forgery exploits" is activated
         # so we can present a valid crumb or a proper header
-        HEADER="Content-Type:text/plain;charset=UTF-8"
+        CONTENT_TYPE_HEADER="--header Content-Type:text/plain;charset=UTF-8"
         CRUMB=`$WGET --auth-no-challenge --output-document - ${CISERVER}/${CRUMB_ISSUER_URL}`
-        if [ "$CRUMB" != "" ]; then CRUMB="--header $CRUMB"; fi
+        if [ "$CRUMB" != "" ]; then CRUMB_HEADER="--header $CRUMB"; fi
 
         $WGET \
             --auth-no-challenge \
-            --header $HEADER \
-            $CRUMB
+            $CONTENT_TYPE_HEADER \
+            $CRUMB_HEADER \
             --post-data "`$SVNLOOK changed --revision $REV $REPOS`" \
             --output-document "-"\
             --timeout=2 \


### PR DESCRIPTION
The crumb needs to be appended to the headers, not replacing the Content-Type header.
Required for the notification to work on Jenkins LTS 2.277.1 and newer (will throw 500 server error otherwise).

https://issues.jenkins.io/browse/JENKINS-65132

<!-- Please describe your pull request here. -->

- [X ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X ] Ensure that the pull request title represents the desired changelog entry
- [X ] Please describe what you did
- [X ] Link to relevant issues in GitHub or Jira
- [X ] Link to relevant pull requests, esp. upstream and downstream changes
- [X ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
