### PR TITLE
[JENKINS-65862] exclude asm and common-beanutils from commons-digester3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,16 @@ THE SOFTWARE.
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-digester3</artifactId>
       <version>3.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
See [JENKINS-65862](https://issues.jenkins.io/browse/JENKINS-65862)
When `commons-digester3` was added as a dependency, it bundled in `asm` and `common-beanutils`, both of which are included in core. This PR excludes `asm` and `common-beanutils` from `commons-digester3`

upstream of https://github.com/jenkinsci/workflow-scm-step-plugin/pull/53

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
