### PR TITLE
Safer way of excluding ASM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,15 +215,24 @@ THE SOFTWARE.
       <artifactId>commons-digester3</artifactId>
       <version>3.2</version>
       <exclusions>
+        <!--
+          cglib depends on ASM 3, which is incompatible with ASM 4 and later. Core includes ASM 9.
+          Exclude it here so that we can pull in a version with shaded ASM below.
+        -->
         <exclusion>
-          <groupId>asm</groupId>
-          <artifactId>asm</artifactId>
+          <groupId>cglib</groupId>
+          <artifactId>cglib</artifactId>
         </exclusion>
         <exclusion>
           <groupId>commons-beanutils</groupId>
           <artifactId>commons-beanutils</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>cglib</groupId>
+      <artifactId>cglib-nodep</artifactId>
+      <version>2.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Amends #257. As I have discovered on this saga, ASM 4 and later are good about compatibility, but ASM 3 and earlier are not. Unfortunately Digester depends on ASM 3 indirectly, through cglib:

```
[INFO] +- org.apache.commons:commons-digester3:jar:3.2:compile
[INFO] |  +- cglib:cglib:jar:2.2.2:compile
[INFO] |  |  \- asm:asm:jar:3.3.1:compile
[INFO] |  \- commons-beanutils:commons-beanutils:jar:1.9.3:compile
```

So by excluding ASM but still packaging cglib, as was done in #257, we are running cglib (compiled against 3.3.1) against whatever ASM is provided by core (9.1), which seems risky.

This change instead excludes _cglib_ and then adds `cglib-nodep`, which bundles its own repackaged version of ASM. This way Digester still gets what it needs (cglib 2.2.2) without worrying about any unnecessary risk.

CC @timja @car-roll 