### PR TITLE
Stop setting `useAntClassLoader` which nothing consumes

### DIFF
--- a/src/test/java/hudson/scm/AbstractSubversionTest.java
+++ b/src/test/java/hudson/scm/AbstractSubversionTest.java
@@ -1,6 +1,5 @@
 package hudson.scm;
 
-import hudson.ClassicPluginStrategy;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Launcher.LocalLauncher;
@@ -128,9 +127,5 @@ public abstract class AbstractSubversionTest {
                 retries++;
             }
         }
-    }
-
-    static {
-        ClassicPluginStrategy.useAntClassLoader = true;
     }
 }


### PR DESCRIPTION
This field has been [unused since 1.527](https://github.com/jenkinsci/jenkins/commit/47de54d070f67af95b4fefb6d006a72bb31a5cb8). Setting it is pointless. Stop doing so, so that one day we might be able to actually remove it.

CC @timja