### PR TITLE
Drop dependency on Commons Codec

### DIFF
--- a/src/test/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinitionTest.java
+++ b/src/test/java/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinitionTest.java
@@ -20,10 +20,10 @@ import java.net.Socket;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import jenkins.model.Jenkins;
-import org.apache.commons.codec.binary.Base64;
 import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
@@ -141,7 +141,7 @@ public class ListSubversionTagsParameterDefinitionTest {
                                 System.err.println("Received: " + line);
                                 String magic = "Authorization: Basic ";
                                 if (line.startsWith(magic)) {
-                                    sniffed = new String(Base64.decodeBase64(line.substring(magic.length())));
+                                    sniffed = new String(Base64.getDecoder().decode(line.substring(magic.length())));
                                     System.err.println("decoded to: " + sniffed);
                                 }
                             }


### PR DESCRIPTION
Java 8 includes a built-in Base64 decoder, so there is no reason to depend on a third-party library. Using the built-in Java Platform functionality simplifies maintenance.