### PR TITLE
Compatibility with Git plugin

### DIFF
--- a/src/main/java/hudson/scm/browsers/Phabricator.java
+++ b/src/main/java/hudson/scm/browsers/Phabricator.java
@@ -8,6 +8,7 @@ import hudson.scm.SubversionRepositoryBrowser;
 import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.jenkinsci.Symbol;
 
 import java.io.IOException;
 import java.net.URL;
@@ -101,6 +102,7 @@ public class Phabricator extends SubversionRepositoryBrowser {
     }
 
     @Extension
+    @Symbol("svnPhabricator")
     public static class PhabricatorDescriptor extends Descriptor<RepositoryBrowser<?>> {
         public String getDisplayName() {
             return "Phabricator";


### PR DESCRIPTION
### Context

Discovered in https://github.com/jenkinsci/bom/pull/1337. Blocks https://github.com/jenkinsci/plugin-compat-tester/pull/348.

### Steps to reproduce

Reproducible in `git-plugin` by adding

```xml
@@ -248,6 +248,11 @@
       <artifactId>jenkins-test-harness</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>subversion</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
```

and running `mvn clean verify -Dtest=jenkins.plugins.git.BrowsersJCasCCompatibilityTest#roundTripTest`.

### Expected results

**Note:** These are the _actual_ results with this patch.

The expected result is that the test passes without any exceptions.

### Actual result

The actual result is that the test prints:

```
   9.111 [id=1] WARNING o.j.p.l.c.CompositeTestExecutionListener#lambda$notifyEach$19: TestExecutionListener [org.apache.maven.surefire.junitplatform.RunListenerAdapter] threw exception for method: executionFinished(TestIdentifier [uniqueId = [engine:junit-vintage]/[runner:jenkins.plugins.git.BrowsersJCasCCompatibilityTest]/[test:roundTripTest(jenkins.plugins.git.BrowsersJCasCCompatibilityTest)], parentId = [engine:junit-vintage]/[runner:jenkins.plugins.git.BrowsersJCasCCompatibilityTest], displayName = 'roundTripTest', legacyReportingName = 'roundTripTest', source = MethodSource [className = 'jenkins.plugins.git.BrowsersJCasCCompatibilityTest', methodName = 'roundTripTest', methodParameterTypes = ''], tags = [], type = TEST], TestExecutionResult [status = FAILED, throwable = io.jenkins.plugins.casc.ConfiguratorException: unclassified: error configuring 'unclassified' with class io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator configurator])
java.lang.IllegalStateException: Jenkins.instance is missing. Read the documentation of Jenkins.getInstanceOrNull to see what you are doing wrong.
        at jenkins.model.Jenkins.get(Jenkins.java:802)
        at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.getDescriptor(DataBoundConfigurator.java:217)
        at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.getName(DataBoundConfigurator.java:205)
        at io.jenkins.plugins.casc.ConfiguratorException.getMessage(ConfiguratorException.java:70)
        at java.lang.Throwable.getLocalizedMessage(Throwable.java:392)
        at java.lang.Throwable.toString(Throwable.java:481)
        at java.lang.String.valueOf(String.java:2994)
        at java.lang.StringBuilder.append(StringBuilder.java:131)
        at java.lang.Throwable.printEnclosedStackTrace(Throwable.java:696)
        at java.lang.Throwable.printStackTrace(Throwable.java:668)
        at java.lang.Throwable.printStackTrace(Throwable.java:722)
        at org.apache.maven.surefire.report.PojoStackTraceWriter.writeTraceToString(PojoStackTraceWriter.java:60)
        at org.apache.maven.surefire.booter.spi.EventChannelEncoder.toStackTrace(EventChannelEncoder.java:418)
        at org.apache.maven.surefire.booter.spi.EventChannelEncoder.access$000(EventChannelEncoder.java:76)
        at org.apache.maven.surefire.booter.spi.EventChannelEncoder$StackTrace.<init>(EventChannelEncoder.java:432)
        at org.apache.maven.surefire.booter.spi.EventChannelEncoder.encode(EventChannelEncoder.java:365)
        at org.apache.maven.surefire.booter.spi.EventChannelEncoder.encode(EventChannelEncoder.java:289)
        at org.apache.maven.surefire.booter.spi.EventChannelEncoder.testError(EventChannelEncoder.java:165)
        at org.apache.maven.surefire.api.booter.ForkingRunListener.testError(ForkingRunListener.java:89)
        at org.apache.maven.surefire.junitplatform.RunListenerAdapter.executionFinished(RunListenerAdapter.java:155)
        at org.junit.platform.launcher.core.CompositeTestExecutionListener.lambda$executionFinished$10(CompositeTestExecutionListener.java:69)
        at org.junit.platform.launcher.core.CompositeTestExecutionListener.lambda$notifyEach$19(CompositeTestExecutionListener.java:95)
        at java.util.ArrayList.forEach(ArrayList.java:1259)
        at org.junit.platform.launcher.core.CompositeTestExecutionListener.notifyEach(CompositeTestExecutionListener.java:93)
        at org.junit.platform.launcher.core.CompositeTestExecutionListener.executionFinished(CompositeTestExecutionListener.java:69)
        at org.junit.platform.launcher.core.ExecutionListenerAdapter.executionFinished(ExecutionListenerAdapter.java:56)
        at org.junit.platform.launcher.core.DelegatingEngineExecutionListener.executionFinished(DelegatingEngineExecutionListener.java:46)
        at org.junit.platform.launcher.core.OutcomeDelayingEngineExecutionListener.executionFinished(OutcomeDelayingEngineExecutionListener.java:63)
        at org.junit.vintage.engine.execution.RunListenerAdapter.fireExecutionFinished(RunListenerAdapter.java:226)
        at org.junit.vintage.engine.execution.RunListenerAdapter.testFinished(RunListenerAdapter.java:192)
        at org.junit.vintage.engine.execution.RunListenerAdapter.testFinished(RunListenerAdapter.java:79)
        at org.junit.runner.notification.SynchronizedRunListener.testFinished(SynchronizedRunListener.java:87)
        at org.junit.runner.notification.RunNotifier$9.notifyListener(RunNotifier.java:225)
        at org.junit.runner.notification.RunNotifier$SafeNotifier.run(RunNotifier.java:72)
        at org.junit.runner.notification.RunNotifier.fireTestFinished(RunNotifier.java:222)
        at org.junit.internal.runners.model.EachTestNotifier.fireTestFinished(EachTestNotifier.java:38)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:372)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
        at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:42)
        at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:80)
        at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:72)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
        at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
        at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:55)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:223)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:175)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:135)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:456)
        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:169)
        at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:595)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:581)
```

If the test was executed with `org.apache.maven.surefire.junit4.JUnit4Provider` (i.e., running tests with Maven's JUnit 4 support, i.e., plugin POM 4.43.1 and earlier) it is a hard error that makes Maven exit non-zero. But with `org.apache.maven.surefire.junitplatform.JUnitPlatformProvider` (i.e., running tests with JUnit Jupiter's Vintage engine, i.e., plugin POM 4.44 and later) it is only a warning that does not make Maven exit non-zero. However either way the exception gets logged.

### Evaluation

These two plugins both define a descriptor with the symbol `phabricator`:

```
WARNING i.j.p.c.i.c.HeteroDescribableConfigurator#handleDuplicateSymbols: Found multiple implementations for symbol = phabricator: [hudson.scm.browsers.Phabricator$PhabricatorDescriptor@62a6352a, hudson.plugins.git.browser.Phabricator$PhabricatorDescriptor@5522fa08]. Please report to plugin maintainer.
```

### Solution

This PR takes the easy way out by disambiguating `hudson.scm.browsers.Phabricator` with the symbol `svnPhabricator`. While technically a breaking change, I would guess there are far fewer users using Phabricator with SVN with Jenkins Configuration as Code (JCasC) than there are using Git. In the meantime, this resolves the symbol error and therefore unblocks https://github.com/jenkinsci/bom/pull/1337 and therefore https://github.com/jenkinsci/plugin-compat-tester/pull/348.

CC @didiez @jetersen @jglick @markewaite