### PR TITLE
[JENKINS-65802] Update SVNKit dependency to 1.10.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.tmatesoft.svnkit</groupId>
       <artifactId>svnkit</artifactId>
-      <version>1.10.9</version>
+      <version>1.10.10</version>
       <exclusions>
         <exclusion>
           <groupId>com.trilead</groupId>
@@ -191,7 +191,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.tmatesoft.svnkit</groupId>
       <artifactId>svnkit-cli</artifactId>
-      <version>1.10.9</version>
+      <version>1.10.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Update SVNKit dependency to the just-released 1.10.10, which contains fixes for aarch64 architectures. This should repair blocker issues using current subversion plugin 2.17.0 on M1 macOS machines.

NOTE: This PR is a sequel to https://github.com/jenkinsci/subversion-plugin/pull/276, but should actually resolve the issue. :)

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [x ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
