### PR TITLE
Removed 1 unnecessary stubbings in SimpleSVNDirEntryHandlerTest.java

### DIFF
--- a/src/test/java/hudson/scm/listtagsparameter/SimpleSVNDirEntryHandlerTest.java
+++ b/src/test/java/hudson/scm/listtagsparameter/SimpleSVNDirEntryHandlerTest.java
@@ -41,7 +41,7 @@ public class SimpleSVNDirEntryHandlerTest {
     @Test
     public void testSortByName() {
         SimpleSVNDirEntryHandler handler = new SimpleSVNDirEntryHandler(null);
-        addEntries(handler);
+        addEntries2(handler);
         
         // TODO: the semantics of using both parameters for handler.getDirs(boolean,boolean)
         // doesn't seem to have been defined properly
@@ -72,7 +72,7 @@ public class SimpleSVNDirEntryHandlerTest {
     @Test
     public void testReverseSortByName() {
         SimpleSVNDirEntryHandler handler = new SimpleSVNDirEntryHandler(null);
-        addEntries(handler);
+        addEntries2(handler);
         List<String> dirs = handler.getDirs(false, true);
         
         Assert.assertEquals(4, dirs.size());
@@ -85,7 +85,7 @@ public class SimpleSVNDirEntryHandlerTest {
     @Test
     public void testFilter() {
         SimpleSVNDirEntryHandler handler = new SimpleSVNDirEntryHandler(".*a.*");
-        addEntries(handler);
+        addEntries2(handler);
         List<String> dirs = handler.getDirs();
         
         Assert.assertEquals(1, dirs.size());
@@ -108,5 +108,22 @@ public class SimpleSVNDirEntryHandlerTest {
         Mockito.when(entry.getDate()).thenReturn(df.parse(lastChanged));
         Mockito.when(entry.getName()).thenReturn(directoryName);
         return entry;
+    }
+
+    private SVNDirEntry getEntry2(String lastChanged, String directoryName) throws ParseException {
+        SVNDirEntry entry = Mockito.mock(SVNDirEntry.class);
+        Mockito.when(entry.getName()).thenReturn(directoryName);
+        return entry;
+    }
+
+    private void addEntries2(SimpleSVNDirEntryHandler handler) {
+        try {
+            handler.handleDirEntry(getEntry2("2011-11-01", "trunk/a"));
+            handler.handleDirEntry(getEntry2("2011-11-01", "trunk/b"));
+            handler.handleDirEntry(getEntry2("2011-10-01", "trunk/x"));
+            handler.handleDirEntry(getEntry2("2011-09-01", "trunk/c"));
+        } catch (ParseException | SVNException e) {
+            Assert.fail(e.toString());
+        }
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
In our analysis of the project, we observed that 
1) 1 stubbing which stubbed `getDate`in `SimpleSVNDirEntryHandlerTest.getEntry` which is invoked in`SimpleSVNDirEntryHandlerTest.addEntries` but never executed by 3 tests: `SimpleSVNDirEntryHandlerTest.testSortByName`, `SimpleSVNDirEntryHandlerTest.testReverseSortByName`, `SimpleSVNDirEntryHandlerTest.testFilter`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.