### PR TITLE
[JENKINS-73281] Use `mina-sshd-api` plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,14 @@ THE SOFTWARE.
       <version>0.3.0-4.v84c6f0f4969e</version>
     </dependency>
     <dependency>
+      <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+      <artifactId>mina-sshd-api-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+      <artifactId>mina-sshd-api-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.tmatesoft.svnkit</groupId>
       <artifactId>svnkit</artifactId>
       <version>1.10.10</version>
@@ -113,6 +121,21 @@ THE SOFTWARE.
           <!-- Provided by eddsa-api plugin -->
           <groupId>net.i2p.crypto</groupId>
           <artifactId>eddsa</artifactId>
+        </exclusion>
+        <!-- Provided by mina-sshd-api-common plugin -->
+        <exclusion>
+          <groupId>org.apache.sshd</groupId>
+          <artifactId>sshd-common</artifactId>
+        </exclusion>
+        <!-- Provided by mina-sshd-api-core plugin -->
+        <exclusion>
+          <groupId>org.apache.sshd</groupId>
+          <artifactId>sshd-core</artifactId>
+        </exclusion>
+        <!-- Provided by Jenkins core -->
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
See [JENKINS-73281](https://issues.jenkins.io/browse/JENKINS-73281). The `sample-plugin` test in `jenkinsci/bom` started failing on the Jetty 12 EE 8 branch with the stack trace shown in the ticket. The root cause of the problem was unrelated to the Jetty 12 EE 8 upgrade but happened to be exposed by the reshuffled classpath of Jetty 12 EE 8; namely, the Subversion test JAR was pulling in an old version of `mina-sshd-api-common`. Somehow the reshuffled classpath on Jetty 12 EE 8 made this old version take precedence, resulting in the failure:

```
[INFO] +- org.jenkins-ci.plugins:subversion:jar:1256.vee91953217b_6:test
[INFO] |  +- org.tmatesoft.svnkit:svnkit:jar:1.10.10:test
[INFO] |  |  +- org.apache.sshd:sshd-common:jar:2.8.0:test <---- outdated version that causes `InjectedTest` to fail
```

The fix is to exclude this old version to allow (the latest version of) this library to be pulled in from the corresponding library plugin.

### Testing done

Reproduced the problem described in the ticket in `jenkinsci/bom`; with the incremental build from this PR, can no longer reproduce the issue.