### PR TITLE
Remove JNA from JPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,11 @@ THE SOFTWARE.
           <groupId>com.trilead</groupId>
           <artifactId>trilead-ssh2</artifactId>
         </exclusion>
+        <!-- Provided by Jenkins core -->
+        <exclusion>
+          <groupId>net.java.dev.jna</groupId>
+          <artifactId>jna</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>net.java.dev.jna</groupId>
           <artifactId>jna-platform</artifactId>


### PR DESCRIPTION
Stop bundling `jna-5.13.0.jar`. `jna-5.14.0.jar` is already bundled by Jenkins core, and its copy of these classes takes precedence.

### Testing done

None