### PR TITLE
Require 2.440.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@ THE SOFTWARE.
     <useBeta>true</useBeta>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.426.3</jenkins.version>
+    <jenkins.version>2.440.3</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <spotbugs.threshold>High</spotbugs.threshold> <!-- TODO some violations remaining -->
   </properties>
@@ -82,8 +82,8 @@ THE SOFTWARE.
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.426.x</artifactId>
-        <version>2555.v3190a_8a_c60c6</version>
+        <artifactId>bom-2.440.x</artifactId>
+        <version>3143.v347db_7c6db_6e</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
PCT detected some errors with the last two releases on 2.426.x and earlier, so require 2.440.3 or newer.

### Testing done

CI build