### PR TITLE
Remove unnecessary version declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,6 @@ THE SOFTWARE.
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>eddsa-api</artifactId>
-      <version>0.3.0-4.v84c6f0f4969e</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins.mina-sshd-api</groupId>


### PR DESCRIPTION
Now that we're on a recent BOM version, this version number is not needed anymore.

### Testing done

`mvn clean verify -Dtest=InjectedTest`