### PR TITLE
[JENKINS-73900] Un-inline JS in `ModuleLocation/config.jelly` and fix validation logic

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -2352,23 +2352,25 @@ public class SubversionSCM extends SCM {
             }
         }
 
-        /**
-         * @deprecated retained for API compatibility only
-         */
-        @CheckForNull
-        @Deprecated
-        @RequirePOST
-        public FormValidation doCheckRemote(StaplerRequest req, @AncestorInPath AbstractProject context, @QueryParameter String value, @QueryParameter String credentialsId) {
-            Jenkins instance = Jenkins.getInstance();
-            if (instance != null) {
-                ModuleLocation.DescriptorImpl d = instance.getDescriptorByType(ModuleLocation.DescriptorImpl.class);
-                if (d != null) {
-                    return d.doCheckCredentialsId(req, context, value, credentialsId);
-                }
-            }
-
-            return FormValidation.warning("Unable to check remote.");
-        }
+//        /**
+//         * @deprecated retained for API compatibility only
+//         */
+//        @CheckForNull
+//        @Deprecated
+//        @RequirePOST
+//        public FormValidation doCheckRemote(StaplerRequest req, @AncestorInPath AbstractProject context, @QueryParameter String value, @QueryParameter String credentialsId) {
+//
+//            System.out.println("doCheckRemote NOT QHAT WE NEED");
+//            Jenkins instance = Jenkins.getInstance();
+//            if (instance != null) {
+//                ModuleLocation.DescriptorImpl d = instance.getDescriptorByType(ModuleLocation.DescriptorImpl.class);
+//                if (d != null) {
+//                    return d.doCheckCredentialsId(req, context, value, credentialsId);
+//                }
+//            }
+//
+//            return FormValidation.warning("Unable to check remote.");
+//        }
 
         /**
          * @deprecated use {@link #checkRepositoryPath(hudson.model.Job, org.tmatesoft.svn.core.SVNURL, com.cloudbees.plugins.credentials.common.StandardCredentials)}
@@ -2544,10 +2546,11 @@ public class SubversionSCM extends SCM {
          */
         @RequirePOST
         public FormValidation doCheckRevisionPropertiesSupported(@AncestorInPath Item context,
-                                                                 @QueryParameter String value,
-                                                                 @QueryParameter String credentialsId,
-                                                                 @QueryParameter String excludedRevprop) throws IOException, ServletException {
-              String v = Util.fixNull(value).trim();
+                                                                 @QueryParameter String excludedRevprop,
+                                                                 @QueryParameter("remoteLocation") String remoteLocation,
+                                                                 @QueryParameter("credentialsId") String credentialsId
+                                                                 ) throws IOException, ServletException {
+              String v = Util.fixNull(remoteLocation).trim();
             if (v.length() == 0)
                 return FormValidation.ok();
 
@@ -3200,10 +3203,10 @@ public class SubversionSCM extends SCM {
              */
             @RequirePOST
             public FormValidation doCheckRemote(/* TODO unused, delete */StaplerRequest req, @AncestorInPath Item context,
-                    @QueryParameter String remote) {
+                    @QueryParameter String value) {
 
                 // repository URL is required
-                String url = Util.fixEmptyAndTrim(remote);
+                String url = Util.fixEmptyAndTrim(value);
                 if (url == null) {
                     return FormValidation.error(Messages.SubversionSCM_doCheckRemote_required());
                 }
@@ -3228,7 +3231,7 @@ public class SubversionSCM extends SCM {
              */
             @RequirePOST
             public FormValidation doCheckCredentialsId(StaplerRequest req, @AncestorInPath Item context,
-                    @QueryParameter String remote, @QueryParameter String value) {
+                    @QueryParameter("remoteLocation") String remote, @QueryParameter String value) {
 
                 // Test the connection only if we may use the credentials (cf. hudson.plugins.git.UserRemoteConfig.DescriptorImpl.doCheckUrl)
                 if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER) ||

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -54,7 +54,6 @@ import com.cloudbees.plugins.credentials.domains.SchemeSpecification;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
-import com.sun.tools.jconsole.JConsoleContext;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -54,6 +54,7 @@ import com.cloudbees.plugins.credentials.domains.SchemeSpecification;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import com.sun.tools.jconsole.JConsoleContext;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -2546,15 +2547,16 @@ public class SubversionSCM extends SCM {
          */
         @RequirePOST
         public FormValidation doCheckRevisionPropertiesSupported(@AncestorInPath Item context,
-                                                                 @QueryParameter String excludedRevprop,
-                                                                 @QueryParameter("remoteLocation") String remoteLocation,
-                                                                 @QueryParameter("credentialsId") String credentialsId
+                                                                 @QueryParameter String value,
+                                                                 @QueryParameter("svn.remote.loc") String remoteLocation,
+                                                                 @QueryParameter("svn.remote.cred") String credentialsId
                                                                  ) throws IOException, ServletException {
+
               String v = Util.fixNull(remoteLocation).trim();
             if (v.length() == 0)
                 return FormValidation.ok();
 
-            String revprop = Util.fixNull(excludedRevprop).trim();
+            String revprop = Util.fixNull(value).trim();
             if (revprop.length() == 0)
                 return FormValidation.ok();
 

--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -2352,25 +2352,24 @@ public class SubversionSCM extends SCM {
             }
         }
 
-//        /**
-//         * @deprecated retained for API compatibility only
-//         */
-//        @CheckForNull
-//        @Deprecated
-//        @RequirePOST
-//        public FormValidation doCheckRemote(StaplerRequest req, @AncestorInPath AbstractProject context, @QueryParameter String value, @QueryParameter String credentialsId) {
-//
-//            System.out.println("doCheckRemote NOT QHAT WE NEED");
-//            Jenkins instance = Jenkins.getInstance();
-//            if (instance != null) {
-//                ModuleLocation.DescriptorImpl d = instance.getDescriptorByType(ModuleLocation.DescriptorImpl.class);
-//                if (d != null) {
-//                    return d.doCheckCredentialsId(req, context, value, credentialsId);
-//                }
-//            }
-//
-//            return FormValidation.warning("Unable to check remote.");
-//        }
+        /**
+         * @deprecated retained for API compatibility only
+         */
+        @CheckForNull
+        @Deprecated
+        @RequirePOST
+        public FormValidation doCheckRemote(StaplerRequest req, @AncestorInPath AbstractProject context, @QueryParameter String value, @QueryParameter String credentialsId) {
+
+            Jenkins instance = Jenkins.getInstance();
+            if (instance != null) {
+                ModuleLocation.DescriptorImpl d = instance.getDescriptorByType(ModuleLocation.DescriptorImpl.class);
+                if (d != null) {
+                    return d.doCheckCredentialsId(req, context, value, credentialsId);
+                }
+            }
+
+            return FormValidation.warning("Unable to check remote.");
+        }
 
         /**
          * @deprecated use {@link #checkRepositoryPath(hudson.model.Job, org.tmatesoft.svn.core.SVNURL, com.cloudbees.plugins.credentials.common.StandardCredentials)}

--- a/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/config.jelly
@@ -25,31 +25,10 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 
-<!--   independent check to validate remote URL. No Other fields are required.-->
   <f:entry title="${%Repository URL}" field="remoteLocation" help="/scm/SubversionSCM/url-help">
     <f:textbox checkUrl="${rootURL}/descriptorByName/hudson.scm.SubversionSCM%24ModuleLocation/checkRemote" checkDependsOn=""/>
   </f:entry>
 
-<!--  <f:invisibleEntry>-->
-<!--    <f:textbox name="excludedRevprop" value="${it.scm.excludedRevprop}"  checkUrl="${rootURL}/descriptorByName/hudson.scm.SubversionSCM/checkRevisionPropertiesSupported" checkDependsOn="excludedRevProp remoteLocation credentialsId"/>-->
-<!--  </f:invisibleEntry>-->
-
-
-<!--  default behavior here does not trigger a request for excludedRevprop./-->
-
-<!--    <f:textbox checkMethod="post" id="svn.remote.loc" onchange="{ /* workaround for JENKINS-19124 */-->
-<!--            var self=this.targetElement ? this.targetElement : this;-->
-<!--            var r=findNextFormItem(self,'credentialsId');-->
-<!--            r.onchange(r);-->
-<!--            if (self===document.getElementById('svn.remote.loc')){-->
-<!--                r=findNextFormItem(self,'excludedRevprop');-->
-<!--                r.onchange(r);-->
-<!--            }-->
-<!--            self=null;-->
-<!--            r=null;-->
-<!--    }"/>-->
-
-<!--  The below works as if. If you check the html element we can see the proper checkUrl and checkDependsOn=remoteLocation-->
   <f:entry title="${%Credentials}" field="credentialsId">
     <c:select checkMethod="post"/>
   </f:entry>

--- a/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/config.jelly
@@ -24,22 +24,36 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-  <f:entry title="${%Repository URL}" field="remote" help="/scm/SubversionSCM/url-help">
-    <f:textbox checkMethod="post" id="svn.remote.loc" onchange="{ /* workaround for JENKINS-19124 */
-            var self=this.targetElement ? this.targetElement : this;
-            var r=findNextFormItem(self,'credentialsId');
-            r.onchange(r);
-            if (self===document.getElementById('svn.remote.loc')){
-                r=findNextFormItem(self,'excludedRevprop');
-                r.onchange(r);
-            }
-            self=null;
-            r=null;
-    }"/>
+
+<!--   independent check to validate remote URL. No Other fields are required.-->
+  <f:entry title="${%Repository URL}" field="remoteLocation" help="/scm/SubversionSCM/url-help">
+    <f:textbox checkUrl="${rootURL}/descriptorByName/hudson.scm.SubversionSCM%24ModuleLocation/checkRemote" checkDependsOn=""/>
   </f:entry>
+
+<!--  <f:invisibleEntry>-->
+<!--    <f:textbox name="excludedRevprop" value="${it.scm.excludedRevprop}"  checkUrl="${rootURL}/descriptorByName/hudson.scm.SubversionSCM/checkRevisionPropertiesSupported" checkDependsOn="excludedRevProp remoteLocation credentialsId"/>-->
+<!--  </f:invisibleEntry>-->
+
+
+<!--  default behavior here does not trigger a request for excludedRevprop./-->
+
+<!--    <f:textbox checkMethod="post" id="svn.remote.loc" onchange="{ /* workaround for JENKINS-19124 */-->
+<!--            var self=this.targetElement ? this.targetElement : this;-->
+<!--            var r=findNextFormItem(self,'credentialsId');-->
+<!--            r.onchange(r);-->
+<!--            if (self===document.getElementById('svn.remote.loc')){-->
+<!--                r=findNextFormItem(self,'excludedRevprop');-->
+<!--                r.onchange(r);-->
+<!--            }-->
+<!--            self=null;-->
+<!--            r=null;-->
+<!--    }"/>-->
+
+<!--  The below works as if. If you check the html element we can see the proper checkUrl and checkDependsOn=remoteLocation-->
   <f:entry title="${%Credentials}" field="credentialsId">
     <c:select checkMethod="post"/>
   </f:entry>
+
   <f:entry title="${%Local module directory}" field="local">
     <f:textbox value="${instance!=null?instance.local:'.'}"/>
   </f:entry>

--- a/src/main/resources/hudson/scm/SubversionSCM/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/config.jelly
@@ -57,17 +57,20 @@ THE SOFTWARE.
         <f:textarea />
     </f:entry>
 
-      <!--      findNearby() method in hudson-behavior.js is unable to find remoteLocation and credentialsId fields. even with "../ + ../ .. etc it is unable to find the fields.-->
-<!--      Not sure how to proceed from here. -->
+    <st:adjunct includes="hudson.scm.SubversionSCM.excludedRevprop-validation" />
+
+    <f:invisibleEntry>
+        <f:entry field="svn.remote.loc" >
+            <f:textbox />
+        </f:entry>
+        <f:entry field="svn.remote.cred" >
+            <f:textbox />
+      </f:entry>
+    </f:invisibleEntry>
+
     <f:entry title="${%Exclusion revprop name}" field="excludedRevprop">
-        <f:textbox checkUrl="${rootURL}/descriptorByName/hudson.scm.SubversionSCM/checkRevisionPropertiesSupported" checkDependsOn="remoteLocation credentialsId" />
+        <f:textbox checkUrl="${rootURL}/descriptorByName/hudson.scm.SubversionSCM/checkRevisionPropertiesSupported" checkDependsOn="svn.remote.loc svn.remote.cred" />
     </f:entry>
-
-
-
-<!--      <f:entry title="${%Exclusion revprop name}" field="excludedRevprop">-->
-<!--          <f:textbox checkMethod="post" checkUrl="'descriptorByName/hudson.scm.SubversionSCM/checkRevisionPropertiesSupported?value='+toValue(document.getElementById('remoteLocation'))+'&amp;credentialsId='+toValue(document.getElementById('svn.remote.cred'))+'&amp;excludedRevprop='+toValue(this)"/>-->
-<!--      </f:entry>-->
 
     <f:entry title="${%Filter changelog}" field="filterChangelog">
         <f:checkbox />

--- a/src/main/resources/hudson/scm/SubversionSCM/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/config.jelly
@@ -56,9 +56,19 @@ THE SOFTWARE.
     <f:entry title="${%Excluded Commit Messages}" field="excludedCommitMessages">
         <f:textarea />
     </f:entry>
+
+      <!--      findNearby() method in hudson-behavior.js is unable to find remoteLocation and credentialsId fields. even with "../ + ../ .. etc it is unable to find the fields.-->
+<!--      Not sure how to proceed from here. -->
     <f:entry title="${%Exclusion revprop name}" field="excludedRevprop">
-        <f:textbox checkMethod="post" checkUrl="'descriptorByName/hudson.scm.SubversionSCM/checkRevisionPropertiesSupported?value='+toValue(document.getElementById('svn.remote.loc'))+'&amp;credentialsId='+toValue(document.getElementById('svn.remote.cred'))+'&amp;excludedRevprop='+toValue(this)"/>
+        <f:textbox checkUrl="${rootURL}/descriptorByName/hudson.scm.SubversionSCM/checkRevisionPropertiesSupported" checkDependsOn="remoteLocation credentialsId" />
     </f:entry>
+
+
+
+<!--      <f:entry title="${%Exclusion revprop name}" field="excludedRevprop">-->
+<!--          <f:textbox checkMethod="post" checkUrl="'descriptorByName/hudson.scm.SubversionSCM/checkRevisionPropertiesSupported?value='+toValue(document.getElementById('remoteLocation'))+'&amp;credentialsId='+toValue(document.getElementById('svn.remote.cred'))+'&amp;excludedRevprop='+toValue(this)"/>-->
+<!--      </f:entry>-->
+
     <f:entry title="${%Filter changelog}" field="filterChangelog">
         <f:checkbox />
     </f:entry>

--- a/src/main/resources/hudson/scm/SubversionSCM/excludedRevprop-validation.js
+++ b/src/main/resources/hudson/scm/SubversionSCM/excludedRevprop-validation.js
@@ -1,0 +1,31 @@
+Behaviour.specify("input[name='_.remoteLocation']", 'SubversionSCM.RemoteLocation', 0, function(element) {
+    element.addEventListener('blur', updateHiddenFields);
+});
+
+Behaviour.specify("select[name='_.credentialsId'][filldependson='remote']", 'SubversionSCM.CredentialsId', 0, function(element) {
+    element.addEventListener('change', updateHiddenFields);
+});
+
+function updateHiddenFields() {
+
+    var remoteLocationElement = document.querySelector("input[name='_.remoteLocation']");
+    var credentialsIdElement = document.querySelector("select[name='_.credentialsId'][filldependson='remote']");
+    var selectedOption = credentialsIdElement.options[credentialsIdElement.selectedIndex].value;
+
+
+    var remoteHidden = document.querySelector("input[name='_.svn.remote.loc']");
+    var credentialsHidden = document.querySelector("input[name='_.svn.remote.cred']");
+
+    if (remoteHidden) {
+        remoteHidden.value = remoteLocationElement.value;
+    }
+
+    if (credentialsHidden) {
+        credentialsHidden.value = selectedOption;
+    }
+
+    var revPropField = document.querySelector("input[name='_.excludedRevprop']");
+    if (revPropField) {
+        revPropField.dispatchEvent(new Event('change'));
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

[JENKINS-73900](https://issues.jenkins.io/browse/JENKINS-73900)

This PR fixes the original form validation logic in the subversion plugin for validating the `excludedRevprop` property.

https://www.loom.com/share/4d72b9426db94ef6bfd68771bb83c832

With CSP Restrictive you can see that the subversion plugin does not have any issues, but there is broken functionality in regards to adding new credentials

https://www.loom.com/share/ded912c8305d42b7b5440af23ab1805a


```
// HACK: can be removed once base version of Jenkins has fix of https://issues.jenkins-ci.org/browse/JENKINS-26578
    // conditionally include the adjunct resources as AdjunctManager doesn't do this correctly for CSS
    if (!document.getElementById('lib.credentials.select.select')) {
      var link = document.createElement('link');
      link.id = 'lib.credentials.select.select';
      link.rel = 'stylesheet';
      link.type = 'text/css';
      link.href = "/jenkins/adjuncts/4daa1914/lib/credentials/select/select.css";
      link.media = 'all';
      document.getElementsByTagName('head')[0].appendChild(link);
      var script = document.createElement('script');
      script.type = 'text/javascript';
      script.src = "/jenkins/adjuncts/4daa1914/lib/credentials/select/select.js";
      document.getElementsByTagName('body')[0].appendChild(script);
    }

```



### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
