### PR TITLE
Allow '.' in usernames

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -2502,9 +2502,9 @@ public class SubversionSCM extends SCM {
 
         /**
          * Regular expression for matching one username. Matches 'windows' names ('DOMAIN&#92;user') and
-         * 'normal' names ('user'). Where user (and DOMAIN) has one or more characters in 'a-zA-Z0-9_-')
+         * 'normal' names ('user'). Where user (and DOMAIN) has one or more characters in 'a-zA-Z0-9_.-')
          */
-        private static final Pattern USERNAME_PATTERN = Pattern.compile("([a-zA-Z0-9_-]+\\\\)?+([a-zA-Z0-9_-]+)");
+        private static final Pattern USERNAME_PATTERN = Pattern.compile("([a-zA-Z0-9_.-]+\\\\)?+([a-zA-Z0-9_.-]+)");
 
         /**
          * Validates the excludeUsers field

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -805,7 +805,8 @@ class SubversionSCMTest extends AbstractSubversionTest {
                 "User-Name",
                 "Do-Main\\User-Name",
                 "", // this one is ignored
-                "DOmain12\\User34"};
+                "DOmain12\\User34",
+                "DOMAIN.user" };
 
         for (String validUsername : validUsernames) {
             assertEquals(
@@ -817,8 +818,7 @@ class SubversionSCMTest extends AbstractSubversionTest {
         String[] invalidUsernames = new String[]{
                 "\\user",
                 "DOMAIN\\",
-                "DOMAIN@user",
-                "DOMAIN.user"};
+                "DOMAIN@user"};
 
         for (String invalidUsername : invalidUsernames) {
             assertEquals(


### PR DESCRIPTION
Allow '.' in a username as valid character in exclude username filter.

The same kind of change was done in #233.

### Testing done

mvn verify is running without errors.

before the change:
![image](https://github.com/user-attachments/assets/b9799842-b659-42d2-8fac-cd7dc75e6e2d)

after the change:
![image (1)](https://github.com/user-attachments/assets/e8899597-a883-4204-8dac-7743aee15305)

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


