### PR TITLE
[JENKINS-42798] Add support for cleaning workspace when it is locked.

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -277,6 +277,7 @@ public class SubversionSCM extends SCM {
     private boolean ignoreDirPropChanges;
     private boolean filterChangelog;
     private boolean quietOperation;
+    private boolean cleanupOnLockedWorkspace;
 
     /**
      * A cache of the svn:externals (keyed by project).
@@ -390,8 +391,21 @@ public class SubversionSCM extends SCM {
             String excludedRevprop, String excludedCommitMessages,
             String includedRegions, boolean ignoreDirPropChanges, boolean filterChangelog,
             List<AdditionalCredentials> additionalCredentials) {
-        this(locations, workspaceUpdater, browser, excludedRegions, excludedUsers, excludedRevprop, excludedCommitMessages, 
+        this(locations, workspaceUpdater, browser, excludedRegions, excludedUsers, excludedRevprop, excludedCommitMessages,
             includedRegions, ignoreDirPropChanges, filterChangelog, additionalCredentials, false);
+    }
+
+    /**
+     * @deprecated Use the constructor with {@code cleanupOnLockedWorkspace}.
+     */
+    @Deprecated
+    public SubversionSCM(List<ModuleLocation> locations, WorkspaceUpdater workspaceUpdater,
+                         SubversionRepositoryBrowser browser, String excludedRegions, String excludedUsers,
+                         String excludedRevprop, String excludedCommitMessages,
+                         String includedRegions, boolean ignoreDirPropChanges, boolean filterChangelog,
+                         List<AdditionalCredentials> additionalCredentials, boolean quietOperation) {
+        this(locations, workspaceUpdater, browser, excludedRegions, excludedUsers, excludedRevprop, excludedCommitMessages,
+                includedRegions, ignoreDirPropChanges, filterChangelog, additionalCredentials, quietOperation, false);
     }
 
     @DataBoundConstructor
@@ -399,7 +413,8 @@ public class SubversionSCM extends SCM {
                          SubversionRepositoryBrowser browser, String excludedRegions, String excludedUsers,
                          String excludedRevprop, String excludedCommitMessages,
                          String includedRegions, boolean ignoreDirPropChanges, boolean filterChangelog,
-                         List<AdditionalCredentials> additionalCredentials, boolean quietOperation) {
+                         List<AdditionalCredentials> additionalCredentials, boolean quietOperation,
+                         boolean cleanupOnLockedWorkspace) {
         for (Iterator<ModuleLocation> itr = locations.iterator(); itr.hasNext(); ) {
             ModuleLocation ml = itr.next();
             String remote = Util.fixEmptyAndTrim(ml.remote);
@@ -424,6 +439,7 @@ public class SubversionSCM extends SCM {
         this.ignoreDirPropChanges = ignoreDirPropChanges;
         this.filterChangelog = filterChangelog;
         this.quietOperation = quietOperation;
+        this.cleanupOnLockedWorkspace = cleanupOnLockedWorkspace;
     }
 
     /**
@@ -737,6 +753,11 @@ public class SubversionSCM extends SCM {
       return quietOperation;
     }
 
+    @Exported
+    public boolean isCleanupOnLockedWorkspace() {
+        return cleanupOnLockedWorkspace;
+    }
+
     /**
      * Convenience method solely for testing.
      */
@@ -988,7 +1009,8 @@ public class SubversionSCM extends SCM {
         Set<String> unauthenticatedRealms = new LinkedHashSet<>();
         for (ModuleLocation location : getLocations(env, build)) {
             CheckOutTask checkOutTask =
-                    new CheckOutTask(new CheckOutUpdateTask(build, this, location, build.getTimestamp().getTime(), listener, env, quietOperation));
+                    new CheckOutTask(new CheckOutUpdateTask(build, this, location, build.getTimestamp().getTime(),
+                            listener, env, quietOperation, cleanupOnLockedWorkspace));
             List<External> externals = new ArrayList<>(workspace.act(checkOutTask));
             // save location <---> externals maps
             externalsMap.put(location.remote, externals);
@@ -1070,7 +1092,8 @@ public class SubversionSCM extends SCM {
         private final int workspaceFormat = descriptor().getWorkspaceFormat();
 
         CheckOutUpdateTask(Run<?, ?> build, SubversionSCM parent, ModuleLocation location, Date timestamp,
-                            TaskListener listener, EnvVars env, boolean quietOperation) {
+                           TaskListener listener, EnvVars env, boolean quietOperation,
+                           boolean cleanupOnLockedWorkspace) {
             this.authProvider = parent.createAuthenticationProvider(build.getParent(), location, listener);
             this.timestamp = timestamp;
             this.listener = listener;
@@ -1078,6 +1101,7 @@ public class SubversionSCM extends SCM {
             this.revisions = build.getAction(RevisionParameterAction.class);
             this.task = parent.getWorkspaceUpdater().createTask(workspaceFormat);
             this.quietOperation = quietOperation;
+            this.cleanupOnLockedWorkspace = cleanupOnLockedWorkspace;
         }
 
         List<External> run(File ws) throws IOException {

--- a/src/main/java/hudson/scm/subversion/UpdateUpdater.java
+++ b/src/main/java/hudson/scm/subversion/UpdateUpdater.java
@@ -39,6 +39,11 @@ import org.tmatesoft.svn.core.wc.SVNInfo;
 import org.tmatesoft.svn.core.wc.SVNRevision;
 import org.tmatesoft.svn.core.wc.SVNUpdateClient;
 import org.tmatesoft.svn.core.wc.SVNWCClient;
+import org.tmatesoft.svn.core.wc2.SvnCleanup;
+import org.tmatesoft.svn.core.wc2.SvnGetStatus;
+import org.tmatesoft.svn.core.wc2.SvnOperationFactory;
+import org.tmatesoft.svn.core.wc2.SvnStatus;
+import org.tmatesoft.svn.core.wc2.SvnTarget;
 
 import java.io.File;
 import java.io.IOException;
@@ -155,6 +160,9 @@ public class UpdateUpdater extends WorkspaceUpdater {
                 		fmt.format(r.getDate()) : r.toString();
                 
                 svnuc.setIgnoreExternals(location.isIgnoreExternalsOption());
+                if (cleanupOnLockedWorkspace) {
+                    cleanupWorkspaceIfLocked(local);
+                }
                 preUpdate(location, local);
                 SVNDepth svnDepth = location.getSvnDepthForUpdate();
                 
@@ -186,8 +194,11 @@ public class UpdateUpdater extends WorkspaceUpdater {
                 do {
                     SVNErrorCode errorCode = cause.getErrorMessage().getErrorCode();
                     if (errorCode == SVNErrorCode.WC_LOCKED) {
-                        // work space locked. try fresh check out
-                        listener.getLogger().println("Workspace appear to be locked, so getting a fresh workspace");
+                        if (cleanupOnLockedWorkspace) {
+                            listener.getLogger().println("Workspace is still locked after 'svn cleanup'");
+                            throw new IOException(new UpdaterException("workspace is still locked after 'svn cleanup'", e));
+                        }
+                        listener.getLogger().println("Workspace appears to be locked, so getting a fresh workspace");
                         return delegateTo(new CheckoutUpdater(), workspaceFormat);
                     }
                     if (errorCode == SVNErrorCode.WC_OBSTRUCTED_UPDATE) {
@@ -245,6 +256,37 @@ public class UpdateUpdater extends WorkspaceUpdater {
          */
         protected void preUpdate(ModuleLocation module, File local) throws SVNException, IOException {
             // noop by default
+        }
+
+        private void cleanupWorkspaceIfLocked(File local) throws IOException, SVNException {
+            if (!isWorkspaceLocked(local)) {
+                return;
+            }
+            listener.getLogger().println("Workspace appears to be locked, attempting to run 'svn cleanup'...");
+            SvnOperationFactory operationFactory = new SvnOperationFactory();
+            try {
+                SvnCleanup svnCleanup = operationFactory.createCleanup();
+                svnCleanup.setSingleTarget(SvnTarget.fromFile(local.getCanonicalFile()));
+                svnCleanup.setBreakLocks(true);
+                svnCleanup.run();
+            } finally {
+                operationFactory.dispose();
+            }
+            listener.getLogger().println("Cleanup completed.");
+        }
+
+        private boolean isWorkspaceLocked(File local) throws IOException, SVNException {
+            SvnOperationFactory operationFactory = new SvnOperationFactory();
+            try {
+                SvnGetStatus statusOp = operationFactory.createGetStatus();
+                statusOp.setSingleTarget(SvnTarget.fromFile(local.getCanonicalFile()));
+                statusOp.setDepth(SVNDepth.EMPTY);
+                statusOp.setRemote(false);
+                SvnStatus status = statusOp.run();
+                return status != null && status.isWcLocked();
+            } finally {
+                operationFactory.dispose();
+            }
         }
     }
 

--- a/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
+++ b/src/main/java/hudson/scm/subversion/WorkspaceUpdater.java
@@ -139,6 +139,8 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
          */
         public boolean quietOperation;
 
+        public boolean cleanupOnLockedWorkspace;
+
         /**
          * If the build parameter is specified with specific version numbers, this field captures that. Can be null.
          */
@@ -165,6 +167,7 @@ public abstract class WorkspaceUpdater extends AbstractDescribableImpl<Workspace
             t.revisions = this.revisions;
             t.ws = this.ws;
             t.quietOperation = this.quietOperation;
+            t.cleanupOnLockedWorkspace = this.cleanupOnLockedWorkspace;
 
             return t.perform();
         }

--- a/src/main/resources/hudson/scm/SubversionSCM/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/config.jelly
@@ -38,6 +38,10 @@ THE SOFTWARE.
     <f:checkbox default="true"/>
   </f:entry>
 
+  <f:entry title="${%Cleanup workspace when locked}" field="cleanupOnLockedWorkspace">
+    <f:checkbox default="false"/>
+  </f:entry>
+
   <j:set var="scm" value="${instance}"/>
   <t:listScmBrowsers name="svn.browser" />
   <f:advanced>

--- a/src/main/resources/hudson/scm/SubversionSCM/help-cleanupOnLockedWorkspace.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-cleanupOnLockedWorkspace.html
@@ -1,0 +1,7 @@
+<div>
+  If enabled, Jenkins runs <code>svn cleanup</code> before updating a locked Subversion working copy.
+  <p>
+    If the working copy remains locked, Jenkins fails the build and leaves the workspace in place.
+    If disabled, Jenkins checks out a fresh workspace instead.
+  </p>
+</div>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This MR introduces a new per-job configuration option: "Cleanup workspace when locked". When enabled, the plugin checks for workspace locks in the subversion working copy - typically caused by interrupted operations like svn update or commit. If a lock is found, the plugin runs svn cleanup before proceeding.

![Screenshot 2025-05-09 094153](https://github.com/user-attachments/assets/c71f7c49-8caf-42a7-b805-5f8462232b80)

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Tested by copying one of our large jobs workspaces into a duplicate job, starting a build, interrupting it during an update, and finally running it a second time -> locks are broken as expected (took 9 minutes but in our case the incremental job takes several hours when the workspace is wiped).

![Screenshot 2025-05-09 152241](https://github.com/user-attachments/assets/1efa43da-a854-4531-bea2-f93f5d48c47a)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

resolves https://github.com/jenkinsci/subversion-plugin/issues/1412