### PR TITLE
Resolved mismatch stubbings in SubversionSCMTest.java

### DIFF
--- a/src/test/java/hudson/scm/AbstractSubversionTest.java
+++ b/src/test/java/hudson/scm/AbstractSubversionTest.java
@@ -56,6 +56,16 @@ public abstract class AbstractSubversionTest {
     	r.jenkins.getDescriptorByType(SubversionSCM.DescriptorImpl.class).configure(req, formData);
     }
 
+    protected void configureSvnWorkspaceFormat2(int format) throws Exception {
+        StaplerRequest2 req = mock(StaplerRequest2.class);
+        when(req.getParameter("svn.global_excluded_revprop")).thenReturn(null);
+        when(req.getParameter("svn.workspaceFormat")).thenReturn(""+format);
+
+        JSONObject formData = new JSONObject();
+
+        r.jenkins.getDescriptorByType(SubversionSCM.DescriptorImpl.class).configure(req, formData);
+    }
+
     public static void checkForSvnServe() throws InterruptedException {
         LocalLauncher launcher = new LocalLauncher(StreamTaskListener.fromStdout());
         try {

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -678,7 +678,7 @@ public class SubversionSCMTest extends AbstractSubversionTest {
     
     @Test
     public void multipleRepositoriesSvn17() throws Exception {
-    	configureSvnWorkspaceFormat(SubversionWorkspaceSelector.WC_FORMAT_17);
+    	configureSvnWorkspaceFormat2(SubversionWorkspaceSelector.WC_FORMAT_17);
     	multipleRepositories();
     }
     
@@ -1804,14 +1804,14 @@ public class SubversionSCMTest extends AbstractSubversionTest {
     @Issue("JENKINS-20165")
     @Test
     public void pollingExternalsForFileSvn16() throws Exception {
-        configureSvnWorkspaceFormat(10 /* 1.6 (svn:externals to file) */);
+        configureSvnWorkspaceFormat2(10 /* 1.6 (svn:externals to file) */);
         invokeTestPollingExternalsForFile();
     }
 
     @Issue("JENKINS-20165")
     @Test
     public void pollingExternalsForFileSvn17() throws Exception {
-        configureSvnWorkspaceFormat(SubversionWorkspaceSelector.WC_FORMAT_17);
+        configureSvnWorkspaceFormat2(SubversionWorkspaceSelector.WC_FORMAT_17);
         invokeTestPollingExternalsForFile();
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

# Description

I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In tests `multipleRepositoriesSvn17`, `pollingExternalsForFileSvn16`, and `pollingExternalsForFileSvn17`:
* the `req` object:
i) is created in `AbstractSubversionTest.configureSvnWorkspaceFormat`
ii) during test execution calls the `getParameter` method with argument `"svn.global_excluded_revprop"`, but is not stubbed, resulting in a mismatch stubbing. 

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback. 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch! 
- [ ] Ensure that the pull request title represents the desired changelog entry (Not applicable)
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira (Not applicable)
- [x] Link to relevant pull requests, esp. upstream and downstream changes 
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue (Not applicable)
<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->