### PR TITLE
Migrate plain selects to jenkins fields

### DIFF
--- a/src/main/java/hudson/scm/SubversionSCM.java
+++ b/src/main/java/hudson/scm/SubversionSCM.java
@@ -1791,6 +1791,40 @@ public class SubversionSCM extends SCM {
             }
         }
 
+        /**
+         * Fill Subversion Workspace Version (global setting).
+         * 
+         * Note that SVNKit define its versions in two places:
+         * `svnkit\src\main\java\org\tmatesoft\svn\core\internal\wc\admin\SVNAdminAreaFactory.java`
+         * <pre>
+            int WC_FORMAT_13 = 4;
+            int WC_FORMAT_14 = 8;
+            int WC_FORMAT_15 = 9;
+            int WC_FORMAT_16 = 10;
+         * </pre>
+         * <pre>
+         * `svnkit\src\main\java\org\tmatesoft\svn\core\internal\wc17\db\ISVNWCDb.java`
+            int WC_FORMAT_17 = 29;
+            int WC_FORMAT_18 = 31;
+         * </pre>
+         */
+        public ListBoxModel doFillWorkspaceFormatItems() {
+            ListBoxModel items = new ListBoxModel();
+            items.add("1.4", "8");
+            items.add("1.5", "9");
+            items.add("1.6 (svn:externals to file)", "10");
+            items.add("1.7", "29");
+            items.add("1.8", "31");
+
+            // Note that `workspaceFormat==100` is a hack described (and deprecated) in:
+            // `src\main\java\hudson\scm\SubversionWorkspaceSelector.java`
+            if (workspaceFormat == 100) {
+                items.get(3).selected = true; // select 1.7
+            }
+
+            return items;
+        }
+
         /*package*/ void migratePerJobCredentials() {
             if (credentials == null && !mayHaveLegacyPerJobCredentials ) {
                 // nothing to do here
@@ -2260,7 +2294,8 @@ public class SubversionSCM extends SCM {
         public boolean configure(StaplerRequest2 req, JSONObject formData) throws FormException {
             globalExcludedRevprop = fixEmptyAndTrim(
                     req.getParameter("svn.global_excluded_revprop"));
-            workspaceFormat = Integer.parseInt(req.getParameter("svn.workspaceFormat"));
+
+            workspaceFormat = formData.getInt("workspaceFormat");
             validateRemoteUpToVar = formData.containsKey("validateRemoteUpToVar");
             storeAuthToDisk = formData.containsKey("storeAuthToDisk");
 
@@ -3207,6 +3242,20 @@ public class SubversionSCM extends SCM {
             public String getDisplayName() {
                 return null;
             }
+
+            /**
+             * Fill depthOption drop-down menu.
+             */
+            public ListBoxModel doFillDepthOptionItems() {
+                ListBoxModel items = new ListBoxModel();
+                items.add("infinity"); // selected="${instance == null || instance.depthOption=='infinity'}"
+                items.add("empty");
+                items.add("files");
+                items.add("immediates");
+                items.add("as-it-is(checkout depth files)", "unknown");
+                items.add("as-it-is(checkout depth infinity)", "as-it-is-infinity");
+                return items;
+            }            
 
             public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context, @QueryParameter String remote) {
                 if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER) ||

--- a/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/config.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/ModuleLocation/config.jelly
@@ -36,14 +36,7 @@ THE SOFTWARE.
     <f:textbox value="${instance!=null?instance.local:'.'}"/>
   </f:entry>
   <f:entry title="${%Repository depth}" field="depthOption">
-    <select name="depthOption">
-      <f:option value="infinity" selected="${instance == null || instance.depthOption=='infinity'}">infinity</f:option>
-      <f:option value="empty" selected="${instance.depthOption=='empty'}">empty</f:option>
-      <f:option value="files" selected="${instance.depthOption=='files'}">files</f:option>
-      <f:option value="immediates" selected="${instance.depthOption=='immediates'}">immediates</f:option>
-      <f:option value="unknown" selected="${instance.depthOption=='unknown'}">as-it-is(checkout depth files)</f:option>
-      <f:option value="as-it-is-infinity" selected="${instance.depthOption=='as-it-is-infinity'}">as-it-is(checkout depth infinity)</f:option>
-    </select>
+    <f:select />
   </f:entry>
   <f:entry title="${%Ignore externals}" field="ignoreExternalsOption">
     <f:checkbox default="true"/>

--- a/src/main/resources/hudson/scm/SubversionSCM/global.jelly
+++ b/src/main/resources/hudson/scm/SubversionSCM/global.jelly
@@ -23,33 +23,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<!--
-Note that SVNKit define its versions in two places:
-
-`svnkit\src\main\java\org\tmatesoft\svn\core\internal\wc17\db\ISVNWCDb.java`
-    int WC_FORMAT_17 = 29;
-    int WC_FORMAT_18 = 31;
-
-`svnkit\src\main\java\org\tmatesoft\svn\core\internal\wc\admin\SVNAdminAreaFactory.java`
-    public static final int WC_FORMAT_13 = 4;
-    public static final int WC_FORMAT_14 = 8;
-    public static final int WC_FORMAT_15 = 9;
-    public static final int WC_FORMAT_16 = 10;
-
-Also note that `workspaceFormat==100` is a hack described (and deprecated) in:
-`src\main\java\hudson\scm\SubversionWorkspaceSelector.java`
--->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:section title="${%Subversion}">
-        <f:entry title="${%Subversion Workspace Version}" help="/descriptor/hudson.scm.SubversionSCM/help/workspaceFormat">
-          <select name="svn.workspaceFormat">
-            <f:option value="8"   selected="${descriptor.workspaceFormat==8}"  >1.4</f:option>
-            <f:option value="9"   selected="${descriptor.workspaceFormat==9}"  >1.5</f:option>
-            <f:option value="10"  selected="${descriptor.workspaceFormat==10}" >1.6 (svn:externals to file)</f:option>
-            <f:option value="29"  selected="${descriptor.workspaceFormat==100||descriptor.workspaceFormat==29}">1.7</f:option>
-            <f:option value="31"  selected="${descriptor.workspaceFormat==31}" >1.8</f:option>
-          </select>
+        <f:entry title="${%Subversion Workspace Version}" help="/descriptor/hudson.scm.SubversionSCM/help/workspaceFormat"
+            field="workspaceFormat">
+          <f:select />
         </f:entry>
         <f:entry title="${%Exclusion revprop name}" help="/descriptor/hudson.scm.SubversionSCM/help/excludedRevprop">
             <f:textbox name="svn.global_excluded_revprop" value="${descriptor.globalExcludedRevprop}"/>

--- a/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition/index.jelly
+++ b/src/main/resources/hudson/scm/listtagsparameter/ListSubversionTagsParameterDefinition/index.jelly
@@ -25,15 +25,12 @@
 <!-- this is the page fragment displayed when triggering a new build -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
-  <j:set var="escapeEntryTitleAndDescription" value="false"/>
-  <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
-    <!-- this div is required because of ParametersDefinitionProperty.java#117 -->
-    <div name="parameter">
-      <st:adjunct includes="lib.form.select.select"/>
-      <input type="hidden" name="name" value="${it.name}"/>
-      <select name="tag" class="select" fillUrl="${h.getCurrentDescriptorByNameUrl()}/${it.descriptor.descriptorUrl}/fillTagItems?param=${it.name}">
-        <option value="">${%Retrieving tags…}</option>
-      </select>
-    </div>
-  </f:entry>
+    <j:set var="escapeEntryTitleAndDescription" value="false" />
+    <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
+        <!-- this div is required because of ParametersDefinitionProperty.java#117 -->
+        <div name="parameter">
+            <input type="hidden" name="name" value="${it.name}" />
+            <f:select name="tag" fillUrl="${h.getCurrentDescriptorByNameUrl()}/${it.descriptor.descriptorUrl}/fillTagItems?param=${it.name}" />
+        </div>
+    </f:entry>
 </j:jelly>

--- a/src/test/java/hudson/scm/AbstractSubversionTest.java
+++ b/src/test/java/hudson/scm/AbstractSubversionTest.java
@@ -55,9 +55,9 @@ public abstract class AbstractSubversionTest {
      */
     protected void configureSvnWorkspaceFormat(int format) throws Exception {
         StaplerRequest2 req = mock(StaplerRequest2.class);
-        when(req.getParameter("svn.workspaceFormat")).thenReturn("" + format);
 
         JSONObject formData = new JSONObject();
+        formData.put("workspaceFormat", format);
 
         r.jenkins.getDescriptorByType(SubversionSCM.DescriptorImpl.class).configure(req, formData);
     }
@@ -65,9 +65,9 @@ public abstract class AbstractSubversionTest {
     protected void configureSvnWorkspaceFormat2(int format) throws Exception {
         StaplerRequest2 req = mock(StaplerRequest2.class);
         when(req.getParameter("svn.global_excluded_revprop")).thenReturn(null);
-        when(req.getParameter("svn.workspaceFormat")).thenReturn(""+format);
 
         JSONObject formData = new JSONObject();
+        formData.put("workspaceFormat", format);
 
         r.jenkins.getDescriptorByType(SubversionSCM.DescriptorImpl.class).configure(req, formData);
     }

--- a/src/test/java/hudson/scm/SubversionSCMTest.java
+++ b/src/test/java/hudson/scm/SubversionSCMTest.java
@@ -1526,10 +1526,10 @@ class SubversionSCMTest extends AbstractSubversionTest {
     void externalsToFile() throws Exception {
         Proc server = runSvnServe(getClass().getResource("HUDSON-7539.zip"));
         try {
-            // enable 1.6 mode
-            HtmlForm f = r.createWebClient().goTo("configure").getFormByName("config");
-            f.getSelectByName("svn.workspaceFormat").setSelectedAttribute("10", true);
-            r.submit(f);
+//            // enable 1.6 mode (should not be required anymore)
+//            HtmlForm f = r.createWebClient().goTo("configure").getFormByName("config");
+//            f.getSelectByName("_.workspaceFormat").setSelectedAttribute("10", true);
+//            r.submit(f);
 
             FreeStyleProject p = r.createFreeStyleProject();
             p.setScm(new SubversionSCM("svn://localhost/dir1"));
@@ -1782,10 +1782,10 @@ class SubversionSCMTest extends AbstractSubversionTest {
         Proc p = runSvnServe(getClass().getResource("JENKINS-777.zip"));
 
         try {
-            // enable 1.6 mode
-            HtmlForm f = r.createWebClient().goTo("configure").getFormByName("config");
-            f.getSelectByName("svn.workspaceFormat").setSelectedAttribute("10", true);
-            r.submit(f);
+//            // enable 1.6 mode (should not be required anymore)
+//            HtmlForm f = r.createWebClient().goTo("configure").getFormByName("config");
+//            f.getSelectByName("_.workspaceFormat").setSelectedAttribute("10", true);
+//            r.submit(f);
 
             FreeStyleProject b = r.createFreeStyleProject();
 
@@ -1819,10 +1819,10 @@ class SubversionSCMTest extends AbstractSubversionTest {
         Proc p = runSvnServe(getClass().getResource("JENKINS-777.zip"));
 
         try {
-            // enable 1.6 mode
-            HtmlForm f = r.createWebClient().goTo("configure").getFormByName("config");
-            f.getSelectByName("svn.workspaceFormat").setSelectedAttribute("10", true);
-            r.submit(f);
+//            // enable 1.6 mode (should not be required anymore)
+//            HtmlForm f = r.createWebClient().goTo("configure").getFormByName("config");
+//            f.getSelectByName("_.workspaceFormat").setSelectedAttribute("10", true);
+//            r.submit(f);
 
             FreeStyleProject b = r.createFreeStyleProject();
 


### PR DESCRIPTION
Change `select` to `f:select` which makes Jenkins use standard classes. Also uses [options from a Java model](https://www.jenkins.io/doc/developer/forms/jelly-form-controls/#select-drop-down-menu-with-model-filled-values).

- Tag (build parameter); instead of #347
- Subversion Workspace Version (global config)
- Repository depth (job config)

<!-- Please describe your pull request here. -->

### Testing done

Tested all 3 on local HPI instance. Also tested selecting wc=100 with a manipulated xml.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
