### PR TITLE
Document that included/excluded region regexes match the full path #1431

### DIFF
--- a/src/main/resources/hudson/scm/SubversionSCM/help-excludedRegions.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-excludedRegions.html
@@ -4,6 +4,13 @@
   <p/>
   Each exclusion uses regular expression pattern matching, and must be separated by a new line.
   <p/>
+  Each pattern is matched against the <b>entire</b> Subversion path of the changed file
+  (Java <code>Matcher.matches()</code>), not as a substring search.
+  A relative path such as <code>src/main/web/.*\.html</code> will not match
+  <code>/trunk/myapp/src/main/web/index.html</code>. Write a pattern that covers the whole path,
+  for example <code>/trunk/myapp/src/main/web/.*\.html</code> or
+  <code>.*/src/main/web/.*\.html</code>.
+  <p/>
   <pre>
 	/trunk/myapp/src/main/web/.*\.html
 	/trunk/myapp/src/main/web/.*\.jpeg

--- a/src/main/resources/hudson/scm/SubversionSCM/help-includedRegions.html
+++ b/src/main/resources/hudson/scm/SubversionSCM/help-includedRegions.html
@@ -4,6 +4,12 @@
   <p/>
   Each inclusion uses regular expression pattern matching, and must be separated by a new line.
   <p/>
+  Each pattern is matched against the <b>entire</b> Subversion path of the changed file
+  (Java <code>Matcher.matches()</code>), not as a substring search.
+  A relative path such as <code>c/library1/.*</code> will not match
+  <code>/trunk/myapp/c/library1/Foo.c</code>. Write a pattern that covers the whole path,
+  for example <code>/trunk/myapp/c/library1/.*</code> or <code>.*/c/library1/.*</code>.
+  <p/>
   This is useful when you need to check out an entire resource for building, but only want to do
   the build when a subset has changed.
   <p/>

--- a/src/test/java/hudson/scm/DefaultSVNLogFilterTest.java
+++ b/src/test/java/hudson/scm/DefaultSVNLogFilterTest.java
@@ -191,4 +191,38 @@ class DefaultSVNLogFilterTest extends AbstractSubversionTest {
         assertFalse(filter.isIncluded(e));
     }
 
+    @Issue("JENKINS-45199")
+    @Test
+    void includedAndExcludedRegionsMatchEntirePath() {
+        String path = "/trunk/myapp/src/main/Foo.java";
+        Map<String, SVNLogEntryPath> paths = new HashMap<>();
+        paths.put(path, new SVNLogEntryPath(path, SVNLogEntryPath.TYPE_MODIFIED, null, -1));
+        SVNLogEntry entry = new SVNLogEntry(paths, 1L, new SVNProperties(), false);
+
+        DefaultSVNLogFilter relativeInclude = new DefaultSVNLogFilter(
+                noPatterns, compile("src/main/.*"), noUsers, null, noPatterns, false);
+        assertFalse(relativeInclude.isIncluded(entry),
+                "a relative include pattern must not match a repository path");
+
+        DefaultSVNLogFilter fullInclude = new DefaultSVNLogFilter(
+                noPatterns, compile("/trunk/myapp/src/main/.*"), noUsers, null, noPatterns, false);
+        assertTrue(fullInclude.isIncluded(entry),
+                "a pattern covering the whole path must match");
+
+        DefaultSVNLogFilter prefixInclude = new DefaultSVNLogFilter(
+                noPatterns, compile(".*/src/main/.*"), noUsers, null, noPatterns, false);
+        assertTrue(prefixInclude.isIncluded(entry),
+                "a leading .* include pattern must match");
+
+        DefaultSVNLogFilter relativeExclude = new DefaultSVNLogFilter(
+                compile("src/main/.*"), noPatterns, noUsers, null, noPatterns, false);
+        assertTrue(relativeExclude.isIncluded(entry),
+                "a relative exclude pattern must not filter out a repository path");
+
+        DefaultSVNLogFilter fullExclude = new DefaultSVNLogFilter(
+                compile("/trunk/myapp/src/main/.*"), noPatterns, noUsers, null, noPatterns, false);
+        assertFalse(fullExclude.isIncluded(entry),
+                "a pattern covering the whole path must exclude the change");
+    }
+
 }


### PR DESCRIPTION
## Was this PR generated or assisted by AI?

NO

## Purpose of the pull request

Included/excluded region help said the fields use regular expressions, but not that each pattern has to match the whole Subversion path (`Matcher.matches()`). A relative path such as `src/main/.*` never triggers. I documented that and added a test for #1431 / JENKINS-45199.

## Brief change log

- Spell out full-path matching in the included and excluded region help
- Cover relative vs whole-path patterns in `DefaultSVNLogFilterTest`

## Verify this pull request

This change added tests and can be verified as follows:

- `DefaultSVNLogFilterTest.includedAndExcludedRegionsMatchEntirePath`
